### PR TITLE
Revert python version info

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,7 @@ Run service 😎
 
 Requirements 👍
 ---------------
-* Python_ 3.5.2+, 3.6+
+* Python_ 3.5+
 * aiohttp_
 * aiobotocore_
 * aioamqp_


### PR DESCRIPTION
I tested on 3.5.1, and it works fine now. It will be okay to revert version info as 3.5+.
Please look on.