### PR TITLE
Replace traceback.print_exception with logging.Logger.exception

### DIFF
--- a/tomodachi/container.py
+++ b/tomodachi/container.py
@@ -3,7 +3,6 @@ import asyncio
 import sys
 import logging
 import re
-import traceback
 import types
 import uuid
 from types import ModuleType, TracebackType
@@ -156,9 +155,9 @@ class ServiceContainer(object):
                 self.stop_service()
                 try:
                     if not getattr(e, '_log_level') or getattr(e, '_log_level') in ['DEBUG']:
-                        traceback.print_exception(e.__class__, e, e.__traceback__)
+                        self.logger.exception(str(e))
                 except AttributeError:
-                    traceback.print_exception(e.__class__, e, e.__traceback__)
+                    self.logger.exception(str(e))
 
             if started_futures and any(started_futures):
                 await asyncio.wait([asyncio.ensure_future(func()) for func in started_futures if func])

--- a/tomodachi/launcher.py
+++ b/tomodachi/launcher.py
@@ -5,7 +5,6 @@ import importlib
 import logging
 import datetime
 import uvloop
-import traceback
 import os
 import multidict  # noqa
 import yarl  # noqa
@@ -72,7 +71,7 @@ class ServiceLauncher(object):
                     try:
                         ServiceImporter.import_service_file(file)
                     except (SyntaxError, IndentationError) as e:
-                        traceback.print_exception(e.__class__, e, e.__traceback__)
+                        logging.getLogger('watcher.restart').exception(str(e))
                         logging.getLogger('watcher.restart').warning('Service cannot restart due to errors')
                         cls.restart_services = False
                         return
@@ -88,7 +87,7 @@ class ServiceLauncher(object):
                                 if m == module_name or (len(m) > len(file) and module_name_full_path.endswith(m)):
                                     ServiceImporter.import_module(file)
                         except (SyntaxError, IndentationError) as e:
-                            traceback.print_exception(e.__class__, e, e.__traceback__)
+                            logging.getLogger('watcher.restart').exception(str(e))
                             logging.getLogger('watcher.restart').warning('Service cannot restart due to errors')
                             cls.restart_services = False
                             return
@@ -123,7 +122,7 @@ class ServiceLauncher(object):
                 if exception:
                     raise exception[0]
             except Exception as e:
-                traceback.print_exception(e.__class__, e, e.__traceback__)
+                logging.getLogger('watcher.restart').exception(str(e))
                 if restarting:
                     logging.getLogger('watcher.restart').warning('Service cannot restart due to errors')
                     logging.getLogger('watcher.restart').warning('Trying again in 1.5 seconds')

--- a/tomodachi/transport/schedule.py
+++ b/tomodachi/transport/schedule.py
@@ -3,7 +3,6 @@ import asyncio
 import time
 import pytz
 import tzlocal
-import traceback
 import inspect
 import logging
 from typing import Any, Dict, List, Union, Optional, Callable, Tuple, Awaitable  # noqa
@@ -24,7 +23,7 @@ class Scheduler(Invoker):
                     await routine
             except Exception as e:
                 if not context.get('log_level') or context.get('log_level') in ['DEBUG']:
-                    traceback.print_exception(e.__class__, e, e.__traceback__)
+                    logging.getLogger('transport.schedule').exception(str(e))
 
         context['_schedule_scheduled_functions'] = context.get('_schedule_scheduled_functions', [])
         context['_schedule_scheduled_functions'].append((interval, timestamp, timezone, immediately, func, handler))
@@ -235,7 +234,7 @@ class Scheduler(Invoker):
                     tasks.append(asyncio.ensure_future(asyncio.shield(handler())))
                 except Exception as e:
                     if not context.get('log_level') or context.get('log_level') in ['DEBUG']:
-                        traceback.print_exception(e.__class__, e, e.__traceback__)
+                        logging.getLogger('transport.schedule').exception(str(e))
                     await asyncio.sleep(1)
 
             if tasks:


### PR DESCRIPTION
This pull request replacers traceback.print_exception with logging.Logger.exception to benefit from propagation of the exceptions in the application code.