### PR TITLE
Refactored all internal middleware functionality to use the same base function for executing middlewares.

### DIFF
--- a/examples/basic_examples/amqp_middleware_service.py
+++ b/examples/basic_examples/amqp_middleware_service.py
@@ -6,7 +6,7 @@ from tomodachi.discovery import DummyRegistry
 from tomodachi.protocol import JsonBase
 
 
-async def middleware_function(func: Callable, service: Any, message: Any, routing_key: str, *args: Any, **kwargs: Any) -> Any:
+async def middleware_function(func: Callable, service: Any, message: Any, routing_key: str, context: Dict, *args: Any, **kwargs: Any) -> Any:
     # Functionality before function is called
     service.log('middleware before')
 

--- a/examples/basic_examples/aws_sns_sqs_middleware_service.py
+++ b/examples/basic_examples/aws_sns_sqs_middleware_service.py
@@ -6,7 +6,7 @@ from tomodachi.discovery import AWSSNSRegistration
 from tomodachi.protocol import JsonBase
 
 
-async def middleware_function(func: Callable, service: Any, message: Any, topic: str, *args: Any, **kwargs: Any) -> Any:
+async def middleware_function(func: Callable, service: Any, message: Any, topic: str, context: Dict, *args: Any, **kwargs: Any) -> Any:
     # Functionality before function is called
     service.log('middleware before')
 

--- a/examples/basic_examples/http_middleware_service.py
+++ b/examples/basic_examples/http_middleware_service.py
@@ -1,13 +1,13 @@
 import os
 import asyncio
 import tomodachi
-from typing import Tuple, Callable, Union, Any
+from typing import Tuple, Callable, Union, Any, Dict
 from aiohttp import web
 from tomodachi import http, http_error, http_static, websocket, HttpResponse
 from tomodachi.discovery import DummyRegistry
 
 
-async def middleware_function(func: Callable, service: Any, request: web.Request, *args: Any, **kwargs: Any) -> Any:
+async def middleware_function(func: Callable, service: Any, request: web.Request, context: Dict, *args: Any, **kwargs: Any) -> Any:
     # Functionality before function is called
     service.log('middleware before')
 

--- a/tests/services/http_service.py
+++ b/tests/services/http_service.py
@@ -8,7 +8,7 @@ from tomodachi.transport.http import http, http_error, http_static, websocket, R
 from tomodachi.discovery.dummy_registry import DummyRegistry
 
 
-async def middleware_function(func: Callable, service: Any, request: web.Request) -> Any:
+async def middleware_function(func: Callable, service: Any, request: web.Request, context: Dict, *args: Any, **kwargs: Any) -> Any:
     if request.headers.get('X-Use-Middleware') == 'Set':
         service.middleware_called = True
 

--- a/tomodachi/helpers/middleware.py
+++ b/tomodachi/helpers/middleware.py
@@ -6,6 +6,7 @@ from typing import Callable, List, Any, Dict
 async def execute_middlewares(func: Callable, routine_func: Callable, middlewares: List, *args: Any) -> Any:
     if middlewares:
         middleware_context: Dict = {}
+
         async def middleware_bubble(idx: int = 0, *ma: Any, **mkw: Any) -> Any:
             @functools.wraps(func)
             async def _func(*a: Any, **kw: Any) -> Any:

--- a/tomodachi/helpers/middleware.py
+++ b/tomodachi/helpers/middleware.py
@@ -1,11 +1,11 @@
 import functools
 import inspect
-from typing import Callable, List, Any
+from typing import Callable, List, Any, Dict
 
 
 async def execute_middlewares(func: Callable, routine_func: Callable, middlewares: List, *args: Any) -> Any:
     if middlewares:
-        middleware_context = {}
+        middleware_context: Dict = {}
         async def middleware_bubble(idx: int = 0, *ma: Any, **mkw: Any) -> Any:
             @functools.wraps(func)
             async def _func(*a: Any, **kw: Any) -> Any:

--- a/tomodachi/helpers/middleware.py
+++ b/tomodachi/helpers/middleware.py
@@ -1,0 +1,28 @@
+import functools
+import inspect
+from typing import Callable, List, Any
+
+
+async def execute_middlewares(func: Callable, routine_func: Callable, middlewares: List, *args: Any) -> Any:
+    if middlewares:
+        middleware_context = {}
+        async def middleware_bubble(idx: int = 0, *ma: Any, **mkw: Any) -> Any:
+            @functools.wraps(func)
+            async def _func(*a: Any, **kw: Any) -> Any:
+                return await middleware_bubble(idx + 1, *a, **kw)
+
+            if middlewares and len(middlewares) <= idx + 1:
+                _func = routine_func
+
+            middleware = middlewares[idx]  # type: Callable
+
+            arg_len = len(inspect.getfullargspec(middleware).args) - (len(inspect.getfullargspec(middleware).defaults) if inspect.getfullargspec(middleware).defaults else 0)
+            middleware_arguments = [_func, *args, middleware_context][0:arg_len]
+
+            return await middleware(*middleware_arguments, *ma, **mkw)
+
+        return_value = await middleware_bubble()
+    else:
+        return_value = await routine_func()
+
+    return return_value

--- a/tomodachi/helpers/middleware.py
+++ b/tomodachi/helpers/middleware.py
@@ -5,7 +5,7 @@ from typing import Callable, List, Any, Dict
 
 async def execute_middlewares(func: Callable, routine_func: Callable, middlewares: List, *args: Any) -> Any:
     if middlewares:
-        middleware_context: Dict = {}
+        middleware_context = {}  # type: Dict
 
         async def middleware_bubble(idx: int = 0, *ma: Any, **mkw: Any) -> Any:
             @functools.wraps(func)


### PR DESCRIPTION
Also added a `dict` (`middleware_context`) that will live within the middleware excecution and may pass data along from middleware to middleware.