### PR TITLE
Bug fixes for previous 0.20 releases.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,18 @@
 Changes
 =======
 
+0.20.3 (2020-11-16)
+-------------------
+- Corrects an issue with having multiple invoker decorators to the
+  same service function / task.
+
+- Fixed the ``http.client_max_size`` option, which invalidly always
+  defaulted to ``(1024 ** 2) * 100`` (``100MB``), even though specified
+  to another value.
+
+- Fixes backward compability with ``aiohttp`` 3.5.x.
+
+
 0.20.2 (2020-11-16)
 -------------------
 - Fixes an issue which could cause hot reloading of services to break

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tomodachi"
-version = "0.20.2"
+version = "0.20.3"
 description = "Microservice library on asyncio - HTTP server, websockets, pub/sub messaging for AWS SNS+SQS and RabbitMQ"
 authors = ["Carl Oscar Aaro <hello@carloscar.com>"]
 keywords = ["tomodachi", "microservice", "microservices", "framework", "library", "asyncio", "aws", "sns", "sqs", "amqp", "rabbitmq", "http", "websockets", "easy", "fast", "pubsub", "events", "event based messaging", "messages", "protocol buffers", "protobuf", "async", "message attributes", "filter policy", "distributed architecture", "scalable", "python 3"]

--- a/tests/services/http_service.py
+++ b/tests/services/http_service.py
@@ -74,6 +74,7 @@ class HttpService(tomodachi.Service):
     async def test_aiohttp(self, request: web.Request) -> web.Response:
         return web.Response(body="test aiohttp", status=200, headers={"X-Aiohttp": "test"})
 
+    @http("GET", r"/same-response/?")
     @http("GET", r"/response/?")
     async def test_response_object(self, request: web.Request) -> Response:
         return Response(body="test tomodachi response", status=200, headers={"X-Tomodachi-Response": "test"})

--- a/tests/test_http_service.py
+++ b/tests/test_http_service.py
@@ -102,6 +102,13 @@ def test_request_http_service(monkeypatch: Any, capsys: Any, loop: Any) -> None:
             assert response.headers.get("X-Tomodachi-Response") == "test"
 
         async with aiohttp.ClientSession(loop=loop) as client:
+            response = await client.get("http://127.0.0.1:{}/same-response".format(port))
+            assert response.status == 200
+            assert await response.text() == "test tomodachi response"
+            assert isinstance(response.headers, CIMultiDictProxy)
+            assert response.headers.get("X-Tomodachi-Response") == "test"
+
+        async with aiohttp.ClientSession(loop=loop) as client:
             _id = "123456789"
             response = await client.get("http://127.0.0.1:{}/test/{}".format(port, _id))
             assert response.status == 200

--- a/tomodachi/__version__.py
+++ b/tomodachi/__version__.py
@@ -1,6 +1,6 @@
 from typing import Tuple, Union
 
-__version_info__: Tuple[Union[int, str], ...] = (0, 20, 2)
+__version_info__: Tuple[Union[int, str], ...] = (0, 20, 3)
 __version__: str = "".join([".{}".format(str(n)) if type(n) is int else str(n) for n in __version_info__]).replace(
     ".", "", 1 if type(__version_info__[0]) is int else 0
 )

--- a/tomodachi/invoker/base.py
+++ b/tomodachi/invoker/base.py
@@ -40,16 +40,17 @@ class Invoker(object):
 
                     # Work-around if the decorators are stacked with multiple decorators for the same method
                     if getattr(func, FUNCTION_ATTRIBUTE, None):
+                        decorated_func = cast(Callable, getattr(func, "func"))
                         decorated_cls_func = cast(Callable, getattr(func, "cls_func"))
                         decorated_args = cast(Tuple, getattr(func, "args"))
                         decorated_kwargs = cast(Dict, getattr(func, "kwargs"))
-                        decorated_func = cast(Callable, getattr(func, "func"))
+
                         fn = cast(
                             Callable,
                             cls.decorator(decorated_cls_func)(*decorated_args, **decorated_kwargs)(decorated_func),
                         )
                         setattr(fn, START_ATTRIBUTE, True)
-                        await fn(obj, *args, **kwargs)
+                        await fn(obj, *a, **kw)
 
                     return start_func
 

--- a/tomodachi/transport/http.py
+++ b/tomodachi/transport/http.py
@@ -48,7 +48,7 @@ class HttpException(Exception):
 
 
 class RequestHandler(web_protocol.RequestHandler):  # type: ignore
-    __slots__ = web_protocol.RequestHandler.__slots__ + ("_server_header", "_access_log", "_connection_start_time")
+    __slots__ = web_protocol.RequestHandler.__slots__ + ("_server_header", "_access_log", "_connection_start_time", "_keepalive")
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         self._server_header = kwargs.pop("server_header", None) if kwargs else None
@@ -931,7 +931,7 @@ class HttpTransport(Invoker):
                 )
 
             app: web.Application = web.Application(
-                middlewares=[middleware], client_max_size=(1024 ** 2) * 100  # type: ignore
+                middlewares=[middleware], client_max_size=client_max_size  # type: ignore
             )
             app._set_loop(None)  # type: ignore
             for method, pattern, handler, route_context in context.get("_http_routes", []):

--- a/tomodachi/transport/http.py
+++ b/tomodachi/transport/http.py
@@ -48,7 +48,12 @@ class HttpException(Exception):
 
 
 class RequestHandler(web_protocol.RequestHandler):  # type: ignore
-    __slots__ = web_protocol.RequestHandler.__slots__ + ("_server_header", "_access_log", "_connection_start_time", "_keepalive")
+    __slots__ = web_protocol.RequestHandler.__slots__ + (
+        "_server_header",
+        "_access_log",
+        "_connection_start_time",
+        "_keepalive",
+    )
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         self._server_header = kwargs.pop("server_header", None) if kwargs else None


### PR DESCRIPTION
Bug fixes for previous 0.20 releases.

* Corrects an issue with having multiple invoker decorators to the same service function / task.
* Fixed the `http.client_max_size` option, which invalidly always defaulted to `(1024 ** 2) * 100` (`100MB`), even though specified to another value.
* Fixes backward compability with `aiohttp` 3.5.x.