### PR TITLE
Filter policy type hinting annotation fixes for @tomodachi.aws_sns_sqs decorator

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -58,6 +58,6 @@ jobs:
       - name: python tomodachi.py --dependency-versions
         run: python tomodachi.py --dependency-versions
       - name: Type check with mypy
-        run: mypy ./
+        run: mypy ./ tests/type_hinting_validation.py
       - name: Codecov
         run: codecov --token=${{ secrets.CODECOV_TOKEN }}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 Changes
 =======
 
+0.20.7 (2020-11-27)
+-------------------
+- Reworked type hinting annotations for aws sns sqs filter policies
+  as there were still cases found in the previous tomodachi version
+  that didn't work as they should, and raised mypy errors where a
+  correct filter policy had been applied.
+
+
 0.20.6 (2020-11-24)
 -------------------
 - Fixes a type annotation for the ``aws_sns_sqs`` decorator's keyword

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ flake8:
 
 .PHONY: mypy
 mypy:
-	poetry run mypy ./
+	poetry run mypy ./ tests/type_hinting_validation.py
 
 lint: flake8 mypy
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -182,7 +182,7 @@ python-versions = "*"
 
 [[package]]
 name = "cffi"
-version = "1.14.3"
+version = "1.14.4"
 description = "Foreign Function Interface for Python calling C code."
 category = "main"
 optional = true
@@ -695,7 +695,7 @@ uvloop = ["uvloop"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "a88b0fd8b7c6fa51340d2e91841fd9ad6830f276fb77d80eb7598bd43df06ab6"
+content-hash = "af9f1bce0d15b5d0bbf086bb9c9b255d7d54eb099aecaf96a4a52f1ce7f36c25"
 
 [metadata.files]
 aioamqp = [
@@ -848,42 +848,40 @@ certifi = [
     {file = "certifi-2020.11.8.tar.gz", hash = "sha256:f05def092c44fbf25834a51509ef6e631dc19765ab8a57b4e7ab85531f0a9cf4"},
 ]
 cffi = [
-    {file = "cffi-1.14.3-2-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:3eeeb0405fd145e714f7633a5173318bd88d8bbfc3dd0a5751f8c4f70ae629bc"},
-    {file = "cffi-1.14.3-2-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:cb763ceceae04803adcc4e2d80d611ef201c73da32d8f2722e9d0ab0c7f10768"},
-    {file = "cffi-1.14.3-2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:44f60519595eaca110f248e5017363d751b12782a6f2bd6a7041cba275215f5d"},
-    {file = "cffi-1.14.3-2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c53af463f4a40de78c58b8b2710ade243c81cbca641e34debf3396a9640d6ec1"},
-    {file = "cffi-1.14.3-2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:33c6cdc071ba5cd6d96769c8969a0531be2d08c2628a0143a10a7dcffa9719ca"},
-    {file = "cffi-1.14.3-2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c11579638288e53fc94ad60022ff1b67865363e730ee41ad5e6f0a17188b327a"},
-    {file = "cffi-1.14.3-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:3cb3e1b9ec43256c4e0f8d2837267a70b0e1ca8c4f456685508ae6106b1f504c"},
-    {file = "cffi-1.14.3-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:f0620511387790860b249b9241c2f13c3a80e21a73e0b861a2df24e9d6f56730"},
-    {file = "cffi-1.14.3-cp27-cp27m-win32.whl", hash = "sha256:005f2bfe11b6745d726dbb07ace4d53f057de66e336ff92d61b8c7e9c8f4777d"},
-    {file = "cffi-1.14.3-cp27-cp27m-win_amd64.whl", hash = "sha256:2f9674623ca39c9ebe38afa3da402e9326c245f0f5ceff0623dccdac15023e05"},
-    {file = "cffi-1.14.3-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:09e96138280241bd355cd585148dec04dbbedb4f46128f340d696eaafc82dd7b"},
-    {file = "cffi-1.14.3-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:3363e77a6176afb8823b6e06db78c46dbc4c7813b00a41300a4873b6ba63b171"},
-    {file = "cffi-1.14.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:0ef488305fdce2580c8b2708f22d7785ae222d9825d3094ab073e22e93dfe51f"},
-    {file = "cffi-1.14.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:0b1ad452cc824665ddc682400b62c9e4f5b64736a2ba99110712fdee5f2505c4"},
-    {file = "cffi-1.14.3-cp35-cp35m-win32.whl", hash = "sha256:85ba797e1de5b48aa5a8427b6ba62cf69607c18c5d4eb747604b7302f1ec382d"},
-    {file = "cffi-1.14.3-cp35-cp35m-win_amd64.whl", hash = "sha256:e66399cf0fc07de4dce4f588fc25bfe84a6d1285cc544e67987d22663393926d"},
-    {file = "cffi-1.14.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:15f351bed09897fbda218e4db5a3d5c06328862f6198d4fb385f3e14e19decb3"},
-    {file = "cffi-1.14.3-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4d7c26bfc1ea9f92084a1d75e11999e97b62d63128bcc90c3624d07813c52808"},
-    {file = "cffi-1.14.3-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:23e5d2040367322824605bc29ae8ee9175200b92cb5483ac7d466927a9b3d537"},
-    {file = "cffi-1.14.3-cp36-cp36m-win32.whl", hash = "sha256:a624fae282e81ad2e4871bdb767e2c914d0539708c0f078b5b355258293c98b0"},
-    {file = "cffi-1.14.3-cp36-cp36m-win_amd64.whl", hash = "sha256:de31b5164d44ef4943db155b3e8e17929707cac1e5bd2f363e67a56e3af4af6e"},
-    {file = "cffi-1.14.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:f92cdecb618e5fa4658aeb97d5eb3d2f47aa94ac6477c6daf0f306c5a3b9e6b1"},
-    {file = "cffi-1.14.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:22399ff4870fb4c7ef19fff6eeb20a8bbf15571913c181c78cb361024d574579"},
-    {file = "cffi-1.14.3-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:f4eae045e6ab2bb54ca279733fe4eb85f1effda392666308250714e01907f394"},
-    {file = "cffi-1.14.3-cp37-cp37m-win32.whl", hash = "sha256:b0358e6fefc74a16f745afa366acc89f979040e0cbc4eec55ab26ad1f6a9bfbc"},
-    {file = "cffi-1.14.3-cp37-cp37m-win_amd64.whl", hash = "sha256:6642f15ad963b5092d65aed022d033c77763515fdc07095208f15d3563003869"},
-    {file = "cffi-1.14.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:2791f68edc5749024b4722500e86303a10d342527e1e3bcac47f35fbd25b764e"},
-    {file = "cffi-1.14.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:529c4ed2e10437c205f38f3691a68be66c39197d01062618c55f74294a4a4828"},
-    {file = "cffi-1.14.3-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:8f0f1e499e4000c4c347a124fa6a27d37608ced4fe9f7d45070563b7c4c370c9"},
-    {file = "cffi-1.14.3-cp38-cp38-win32.whl", hash = "sha256:3b8eaf915ddc0709779889c472e553f0d3e8b7bdf62dab764c8921b09bf94522"},
-    {file = "cffi-1.14.3-cp38-cp38-win_amd64.whl", hash = "sha256:bbd2f4dfee1079f76943767fce837ade3087b578aeb9f69aec7857d5bf25db15"},
-    {file = "cffi-1.14.3-cp39-cp39-manylinux1_i686.whl", hash = "sha256:cc75f58cdaf043fe6a7a6c04b3b5a0e694c6a9e24050967747251fb80d7bce0d"},
-    {file = "cffi-1.14.3-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:bf39a9e19ce7298f1bd6a9758fa99707e9e5b1ebe5e90f2c3913a47bc548747c"},
-    {file = "cffi-1.14.3-cp39-cp39-win32.whl", hash = "sha256:d80998ed59176e8cba74028762fbd9b9153b9afc71ea118e63bbf5d4d0f9552b"},
-    {file = "cffi-1.14.3-cp39-cp39-win_amd64.whl", hash = "sha256:c150eaa3dadbb2b5339675b88d4573c1be3cb6f2c33a6c83387e10cc0bf05bd3"},
-    {file = "cffi-1.14.3.tar.gz", hash = "sha256:f92f789e4f9241cd262ad7a555ca2c648a98178a953af117ef7fad46aa1d5591"},
+    {file = "cffi-1.14.4-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:ebb253464a5d0482b191274f1c8bf00e33f7e0b9c66405fbffc61ed2c839c775"},
+    {file = "cffi-1.14.4-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:2c24d61263f511551f740d1a065eb0212db1dbbbbd241db758f5244281590c06"},
+    {file = "cffi-1.14.4-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:9f7a31251289b2ab6d4012f6e83e58bc3b96bd151f5b5262467f4bb6b34a7c26"},
+    {file = "cffi-1.14.4-cp27-cp27m-win32.whl", hash = "sha256:5cf4be6c304ad0b6602f5c4e90e2f59b47653ac1ed9c662ed379fe48a8f26b0c"},
+    {file = "cffi-1.14.4-cp27-cp27m-win_amd64.whl", hash = "sha256:f60567825f791c6f8a592f3c6e3bd93dd2934e3f9dac189308426bd76b00ef3b"},
+    {file = "cffi-1.14.4-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:c6332685306b6417a91b1ff9fae889b3ba65c2292d64bd9245c093b1b284809d"},
+    {file = "cffi-1.14.4-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:d9efd8b7a3ef378dd61a1e77367f1924375befc2eba06168b6ebfa903a5e59ca"},
+    {file = "cffi-1.14.4-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:51a8b381b16ddd370178a65360ebe15fbc1c71cf6f584613a7ea08bfad946698"},
+    {file = "cffi-1.14.4-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:1d2c4994f515e5b485fd6d3a73d05526aa0fcf248eb135996b088d25dfa1865b"},
+    {file = "cffi-1.14.4-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:af5c59122a011049aad5dd87424b8e65a80e4a6477419c0c1015f73fb5ea0293"},
+    {file = "cffi-1.14.4-cp35-cp35m-win32.whl", hash = "sha256:594234691ac0e9b770aee9fcdb8fa02c22e43e5c619456efd0d6c2bf276f3eb2"},
+    {file = "cffi-1.14.4-cp35-cp35m-win_amd64.whl", hash = "sha256:64081b3f8f6f3c3de6191ec89d7dc6c86a8a43911f7ecb422c60e90c70be41c7"},
+    {file = "cffi-1.14.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f803eaa94c2fcda012c047e62bc7a51b0bdabda1cad7a92a522694ea2d76e49f"},
+    {file = "cffi-1.14.4-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:105abaf8a6075dc96c1fe5ae7aae073f4696f2905fde6aeada4c9d2926752362"},
+    {file = "cffi-1.14.4-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:0638c3ae1a0edfb77c6765d487fee624d2b1ee1bdfeffc1f0b58c64d149e7eec"},
+    {file = "cffi-1.14.4-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:7c6b1dece89874d9541fc974917b631406233ea0440d0bdfbb8e03bf39a49b3b"},
+    {file = "cffi-1.14.4-cp36-cp36m-win32.whl", hash = "sha256:155136b51fd733fa94e1c2ea5211dcd4c8879869008fc811648f16541bf99668"},
+    {file = "cffi-1.14.4-cp36-cp36m-win_amd64.whl", hash = "sha256:6bc25fc545a6b3d57b5f8618e59fc13d3a3a68431e8ca5fd4c13241cd70d0009"},
+    {file = "cffi-1.14.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a7711edca4dcef1a75257b50a2fbfe92a65187c47dab5a0f1b9b332c5919a3fb"},
+    {file = "cffi-1.14.4-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:00e28066507bfc3fe865a31f325c8391a1ac2916219340f87dfad602c3e48e5d"},
+    {file = "cffi-1.14.4-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:798caa2a2384b1cbe8a2a139d80734c9db54f9cc155c99d7cc92441a23871c03"},
+    {file = "cffi-1.14.4-cp37-cp37m-win32.whl", hash = "sha256:00a1ba5e2e95684448de9b89888ccd02c98d512064b4cb987d48f4b40aa0421e"},
+    {file = "cffi-1.14.4-cp37-cp37m-win_amd64.whl", hash = "sha256:9cc46bc107224ff5b6d04369e7c595acb700c3613ad7bcf2e2012f62ece80c35"},
+    {file = "cffi-1.14.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:df5169c4396adc04f9b0a05f13c074df878b6052430e03f50e68adf3a57aa28d"},
+    {file = "cffi-1.14.4-cp38-cp38-manylinux1_i686.whl", hash = "sha256:9ffb888f19d54a4d4dfd4b3f29bc2c16aa4972f1c2ab9c4ab09b8ab8685b9c2b"},
+    {file = "cffi-1.14.4-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8d6603078baf4e11edc4168a514c5ce5b3ba6e3e9c374298cb88437957960a53"},
+    {file = "cffi-1.14.4-cp38-cp38-win32.whl", hash = "sha256:b4e248d1087abf9f4c10f3c398896c87ce82a9856494a7155823eb45a892395d"},
+    {file = "cffi-1.14.4-cp38-cp38-win_amd64.whl", hash = "sha256:ec80dc47f54e6e9a78181ce05feb71a0353854cc26999db963695f950b5fb375"},
+    {file = "cffi-1.14.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:840793c68105fe031f34d6a086eaea153a0cd5c491cde82a74b420edd0a2b909"},
+    {file = "cffi-1.14.4-cp39-cp39-manylinux1_i686.whl", hash = "sha256:b18e0a9ef57d2b41f5c68beefa32317d286c3d6ac0484efd10d6e07491bb95dd"},
+    {file = "cffi-1.14.4-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:045d792900a75e8b1e1b0ab6787dd733a8190ffcf80e8c8ceb2fb10a29ff238a"},
+    {file = "cffi-1.14.4-cp39-cp39-win32.whl", hash = "sha256:ba4e9e0ae13fc41c6b23299545e5ef73055213e466bd107953e4a013a5ddd7e3"},
+    {file = "cffi-1.14.4-cp39-cp39-win_amd64.whl", hash = "sha256:f032b34669220030f905152045dfa27741ce1a6db3324a5bc0b96b6c7420c87b"},
+    {file = "cffi-1.14.4.tar.gz", hash = "sha256:1a465cbe98a7fd391d47dce4b8f7e5b921e6cd805ef421d04f5f66ba8f06086c"},
 ]
 chardet = [
     {file = "chardet-3.0.4-py2.py3-none-any.whl", hash = "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,9 @@ aiohttp = ">=3.5.4, <3.8.0"
 colorama = ">=0.3.9, <0.5.0"
 asahi = "^0.1.0"
 
+# typing extensions support for Python 3.7
+typing-extensions = { version = ">=3.7.4", markers = "python_version < \"3.8\"" }
+
 # derived from aiobotocore for dependency resolution speed in same cases.
 botocore = ">=1.12.252, <=1.17.44"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tomodachi"
-version = "0.20.6"
+version = "0.20.7"
 description = "Microservice library on asyncio - HTTP server, websockets, pub/sub messaging for AWS SNS+SQS and RabbitMQ"
 authors = ["Carl Oscar Aaro <hello@carloscar.com>"]
 keywords = ["tomodachi", "microservice", "microservices", "framework", "library", "asyncio", "aws", "sns", "sqs", "amqp", "rabbitmq", "http", "websockets", "easy", "fast", "pubsub", "events", "event based messaging", "messages", "protocol buffers", "protobuf", "async", "message attributes", "filter policy", "distributed architecture", "scalable", "python 3"]

--- a/tests/type_hinting_validation.py
+++ b/tests/type_hinting_validation.py
@@ -1,0 +1,90 @@
+from tomodachi import aws_sns_sqs
+
+aws_sns_sqs(
+    "topic", filter_policy={"currency": ["SEK", "EUR", "USD", "GBP", "CNY"], "amount": [{"numeric": [">=", 2]}]}
+)
+aws_sns_sqs(
+    "topic",
+    filter_policy={
+        "store": ["example_corp"],
+        "event": ["order_cancelled"],
+        "encrypted": [False],
+        "customer_interests": [
+            "basketball",
+            "baseball",
+        ],
+    },
+)
+aws_sns_sqs(
+    "topic",
+    filter_policy={
+        "legacy_id": [1, 2, 3],
+    },
+)
+aws_sns_sqs("topic", filter_policy={"customer_interests": ["rugby", "football", "baseball"]})
+aws_sns_sqs(
+    "topic",
+    filter_policy={
+        "inconsistant_policy_attribute": [4711, False],
+        "inconsistant_policy_attribute_2": [4711, True],
+    },
+)
+aws_sns_sqs(
+    "topic",
+    filter_policy={
+        "store": ["example_corp"],
+        "event": [{"anything-but": "order_cancelled"}],
+        "customer_interests": [
+            "rugby",
+            "football",
+            "baseball",
+        ],
+        "price_usd": [{"numeric": [">=", 100]}],
+    },
+)
+aws_sns_sqs(
+    "topic",
+    filter_policy={
+        "store": [{"exists": True}],
+    },
+)
+aws_sns_sqs(
+    "topic",
+    filter_policy={
+        "customer_interests": [{"anything-but": ["rugby", "tennis"]}],
+        "price_usd": [{"numeric": [">", 100]}],
+        "negative_value": [{"numeric": ["<", 0]}],
+    },
+)
+aws_sns_sqs(
+    "topic",
+    filter_policy={
+        "customer_interests": [{"prefix": "bas"}],
+        "price_usd": [{"numeric": ["=", 301.5]}],
+        "price": [{"anything-but": [100, 500]}],
+        "total": [{"numeric": [">", 0, "<=", 150]}],
+    },
+)
+aws_sns_sqs(
+    "topic",
+    filter_policy={
+        "my_interest": [{"prefix": "bas"}],
+        "my_value": [1, 2, 3, 4711, 3.14],
+        "my_anything": [{"anything-but": [0, 4, 3.14]}],
+        "my_total": [{"numeric": [">", 0, "<=", 150]}],
+        "my_list": [None, "nope", False],
+    },
+)
+aws_sns_sqs(
+    "topic",
+    filter_policy={
+        "my_list": [None, "nope", False],
+        "my_list_two": [None],
+    },
+)
+aws_sns_sqs(
+    "topic",
+    filter_policy={
+        "dev.tomodachi.mypy.filter_key": ["a", "b", "c", 4711],
+    },
+)

--- a/tomodachi/__version__.py
+++ b/tomodachi/__version__.py
@@ -1,6 +1,6 @@
 from typing import Tuple, Union
 
-__version_info__: Tuple[Union[int, str], ...] = (0, 20, 6)
+__version_info__: Tuple[Union[int, str], ...] = (0, 20, 7)
 __version__: str = "".join([".{}".format(str(n)) if type(n) is int else str(n) for n in __version_info__]).replace(
     ".", "", 1 if type(__version_info__[0]) is int else 0
 )

--- a/tomodachi/transport/aws_sns_sqs.py
+++ b/tomodachi/transport/aws_sns_sqs.py
@@ -28,7 +28,6 @@ from tomodachi.helpers.execution_context import (
 from tomodachi.helpers.middleware import execute_middlewares
 from tomodachi.invoker import Invoker
 
-from typing import TypedDict, Literal
 if sys.version_info >= (3, 8):
     from typing import TypedDict, Literal  # isort:skip
 else:

--- a/tomodachi/transport/aws_sns_sqs.py
+++ b/tomodachi/transport/aws_sns_sqs.py
@@ -11,13 +11,22 @@ import logging
 import re
 import time
 import uuid
-from typing import Any, Awaitable, Callable, Dict, List, Literal, Mapping, Match, Optional, Sequence, Set, Tuple, Union, cast
+from typing import Any, Awaitable, Callable, Dict, List, Mapping, Match, Optional, Sequence, Set, Tuple, Union, cast
 
 import aiobotocore
 import aiohttp
 import botocore
 from botocore.parsers import ResponseParserError
-from typing_extensions import TypedDict
+
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal  # type: ignore
+
+try:
+    from typing import TypedDict
+except ImportError:
+    from typing_extensions import TypedDict  # type: ignore
 
 from tomodachi.helpers.dict import merge_dicts
 from tomodachi.helpers.execution_context import (

--- a/tomodachi/transport/aws_sns_sqs.py
+++ b/tomodachi/transport/aws_sns_sqs.py
@@ -576,8 +576,6 @@ class AWSSNSSQSTransport(Invoker):
             else:
                 result[name] = {"DataType": "String", "StringValue": str(value)}
 
-        print(result)
-
         return result
 
     async def publish_message(cls: Any, topic_arn: str, message: Any, message_attributes: Dict, context: Dict) -> str:

--- a/tomodachi/transport/aws_sns_sqs.py
+++ b/tomodachi/transport/aws_sns_sqs.py
@@ -12,7 +12,7 @@ import re
 import sys
 import time
 import uuid
-from typing import Any, Awaitable, Callable, Dict, List, Mapping, Match, Optional, Sequence, Set, Tuple, Union, cast
+from typing import Any, Awaitable, Callable, Dict, List, Mapping, Match, Optional, Set, Tuple, Union, cast
 
 import aiobotocore
 import aiohttp
@@ -73,7 +73,22 @@ ExistsFilterPolicyDict = TypedDict(
     total=False,
 )
 
-FilterPolicyDictType = Mapping[str, List[Optional[Union[str, int, float, AnythingButFilterPolicyDict, NumericFilterPolicyDict, PrefixFilterPolicyDict, ExistsFilterPolicyDict]]]]
+FilterPolicyDictType = Mapping[
+    str,
+    List[
+        Optional[
+            Union[
+                str,
+                int,
+                float,
+                AnythingButFilterPolicyDict,
+                NumericFilterPolicyDict,
+                PrefixFilterPolicyDict,
+                ExistsFilterPolicyDict,
+            ]
+        ]
+    ],
+]
 
 
 class AWSSNSSQSException(Exception):
@@ -224,9 +239,7 @@ class AWSSNSSQSTransport(Invoker):
         *,
         message_envelope: Any = MESSAGE_ENVELOPE_DEFAULT,
         message_protocol: Any = MESSAGE_ENVELOPE_DEFAULT,  # deprecated
-        filter_policy: Optional[
-            Union[str, FilterPolicyDictType]
-        ] = FILTER_POLICY_DEFAULT,
+        filter_policy: Optional[Union[str, FilterPolicyDictType]] = FILTER_POLICY_DEFAULT,
         **kwargs: Any,
     ) -> Any:
         parser_kwargs = kwargs
@@ -551,7 +564,9 @@ class AWSSNSSQSTransport(Invoker):
     def transform_message_attributes_from_response(
         cls, message_attributes: Dict
     ) -> Dict[str, Optional[Union[str, bytes, int, float, bool, List[Optional[Union[str, int, float, bool, object]]]]]]:
-        result: Dict[str, Optional[Union[str, bytes, int, float, bool, List[Optional[Union[str, int, float, bool, object]]]]]] = {}
+        result: Dict[
+            str, Optional[Union[str, bytes, int, float, bool, List[Optional[Union[str, int, float, bool, object]]]]]
+        ] = {}
 
         for name, values in message_attributes.items():
             value = values["Value"]
@@ -562,7 +577,9 @@ class AWSSNSSQSTransport(Invoker):
             elif values["Type"] == "Binary":
                 result[name] = base64.b64decode(value)
             elif values["Type"] == "String.Array":
-                result[name] = cast(Optional[Union[bool, List[Optional[Union[str, int, float, bool, object]]]]], json.loads(value))
+                result[name] = cast(
+                    Optional[Union[bool, List[Optional[Union[str, int, float, bool, object]]]]], json.loads(value)
+                )
 
         return result
 
@@ -1276,9 +1293,7 @@ def aws_sns_sqs(
     *,
     message_envelope: Any = MESSAGE_ENVELOPE_DEFAULT,
     message_protocol: Any = MESSAGE_ENVELOPE_DEFAULT,  # deprecated
-    filter_policy: Optional[
-        Union[str, FilterPolicyDictType]
-    ] = FILTER_POLICY_DEFAULT,
+    filter_policy: Optional[Union[str, FilterPolicyDictType]] = FILTER_POLICY_DEFAULT,
     **kwargs: Any,
 ) -> Callable:
     return cast(

--- a/tomodachi/transport/aws_sns_sqs.py
+++ b/tomodachi/transport/aws_sns_sqs.py
@@ -541,8 +541,8 @@ class AWSSNSSQSTransport(Invoker):
 
     def transform_message_attributes_from_response(
         cls, message_attributes: Dict
-    ) -> Dict[str, Union[str, bytes, int, float, List[Optional[Union[str, int, float, bool, object]]]]]:
-        result: Dict[str, Union[str, bytes, int, float, List[Optional[Union[str, int, float, bool, object]]]]] = {}
+    ) -> Dict[str, Optional[Union[str, bytes, int, float, bool, List[Optional[Union[str, int, float, bool, object]]]]]]:
+        result: Dict[str, Optional[Union[str, bytes, int, float, bool, List[Optional[Union[str, int, float, bool, object]]]]]] = {}
 
         for name, values in message_attributes.items():
             value = values["Value"]
@@ -553,7 +553,7 @@ class AWSSNSSQSTransport(Invoker):
             elif values["Type"] == "Binary":
                 result[name] = base64.b64decode(value)
             elif values["Type"] == "String.Array":
-                result[name] = cast(List[Optional[Union[str, int, float, bool, object]]], json.loads(value))
+                result[name] = cast(Optional[Union[bool, List[Optional[Union[str, int, float, bool, object]]]]], json.loads(value))
 
         return result
 


### PR DESCRIPTION
Reworked type hinting annotations for aws sns sqs filter policies as there were still cases found in the previous tomodachi version that didn't work as they should, and raised mypy errors where a correct filter policy had been applied.