### PR TITLE
Fixes the issue where some definitions of filter policies would result in an error when running mypy – uses 'Sequence' instead of 'List' in type hint definition for filter policy input types

### DIFF
--- a/tests/type_hinting_validation.py
+++ b/tests/type_hinting_validation.py
@@ -1,4 +1,5 @@
 from tomodachi import aws_sns_sqs
+from tomodachi.transport.aws_sns_sqs import FilterPolicyDictType, FilterPolicyDictValueType
 
 aws_sns_sqs(
     "topic", filter_policy={"currency": ["SEK", "EUR", "USD", "GBP", "CNY"], "amount": [{"numeric": [">=", 2]}]}
@@ -86,5 +87,21 @@ aws_sns_sqs(
     "topic",
     filter_policy={
         "dev.tomodachi.mypy.filter_key": ["a", "b", "c", 4711],
+    },
+)
+
+list_value = ["test"]
+
+filter_policy_1: FilterPolicyDictType = {"messageattributename": ["test"]}
+filter_policy_2: FilterPolicyDictType = {"messageattributename": list_value}
+
+filter_policy_dict_value_1: FilterPolicyDictValueType = ["test"]
+filter_policy_dict_value_2: FilterPolicyDictValueType = list_value
+
+
+aws_sns_sqs(
+    "topic",
+    filter_policy={
+        "dev.tomodachi.mypy.filter_key": list_value,
     },
 )

--- a/tomodachi/transport/aws_sns_sqs.py
+++ b/tomodachi/transport/aws_sns_sqs.py
@@ -12,7 +12,7 @@ import re
 import sys
 import time
 import uuid
-from typing import Any, Callable, Dict, List, Mapping, Match, Optional, Set, Tuple, Union, cast
+from typing import Any, Callable, Dict, List, Mapping, Match, Optional, Sequence, Set, Tuple, Union, cast
 
 import aiobotocore
 import aiohttp
@@ -51,7 +51,7 @@ AnythingButFilterPolicyDict = TypedDict(
     total=False,
 )
 
-NumericFilterPolicyValueType = List[Union[int, float, Literal["<", "<=", "=", ">=", ">"]]]
+NumericFilterPolicyValueType = Sequence[Union[int, float, Literal["<", "<=", "=", ">=", ">"]]]
 NumericFilterPolicyDict = TypedDict(
     "NumericFilterPolicyDict",
     {
@@ -76,22 +76,21 @@ ExistsFilterPolicyDict = TypedDict(
     total=False,
 )
 
-FilterPolicyDictType = Mapping[
-    str,
-    List[
-        Optional[
-            Union[
-                str,
-                int,
-                float,
-                AnythingButFilterPolicyDict,
-                NumericFilterPolicyDict,
-                PrefixFilterPolicyDict,
-                ExistsFilterPolicyDict,
-            ]
+FilterPolicyDictValueType = Sequence[
+    Optional[
+        Union[
+            str,
+            int,
+            float,
+            AnythingButFilterPolicyDict,
+            NumericFilterPolicyDict,
+            PrefixFilterPolicyDict,
+            ExistsFilterPolicyDict,
         ]
-    ],
+    ]
 ]
+
+FilterPolicyDictType = Mapping[str, FilterPolicyDictValueType]
 
 connector = ClientConnector()
 


### PR DESCRIPTION
Fixes the issue where some definitions of filter policies would result in an error when running mypy.

For example the following code:

```python
from typing import Any

import tomodachi

ALLOWED_IDS = ["1", "2", "3"]


class Service(tomodachi.Service):
    @tomodachi.aws_sns_sqs("topic", queue_name="service-queue", filter_policy={"allowed_ids": ["1", "2", "3"]})
    async def func_1(self, data: Any, *args: Any, **kwargs: Any) -> None:
        pass

    @tomodachi.aws_sns_sqs("topic", queue_name="service-queue", filter_policy={"allowed_ids": ALLOWED_IDS})
    async def func_2(self, data: Any, *args: Any, **kwargs: Any) -> None:
        pass
```

Would previously have resulted in an error at the `filter_policy` argument value within the decorator to `func_2`:
```
error: Dict entry 0 has incompatible type "str": "List[str]"; 
expected "str": "List[Union[str, float, AnythingButFilterPolicyDict, NumericFilterPolicyDict, 
    PrefixFilterPolicyDict, ExistsFilterPolicyDict, None]]"
```