### PR TITLE
Adds options for SNS and SQS in case the service needs to specify KMS master key id/alias to use for newly created topics / queues

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -47,6 +47,8 @@ jobs:
           TOMODACHI_TEST_SERVICE_UUID: ${{ secrets.TOMODACHI_TEST_SERVICE_UUID }}
           TOMODACHI_TEST_SNS_TOPIC_PREFIX: ${{ secrets.TOMODACHI_TEST_SNS_TOPIC_PREFIX }}
           TOMODACHI_TEST_SQS_QUEUE_PREFIX: ${{ secrets.TOMODACHI_TEST_SQS_QUEUE_PREFIX }}
+          TOMODACHI_TEST_SNS_KMS_MASTER_KEY_ID: ${{ secrets.TOMODACHI_TEST_SNS_KMS_MASTER_KEY_ID }}
+          TOMODACHI_TEST_SQS_KMS_MASTER_KEY_ID: ${{ secrets.TOMODACHI_TEST_SQS_KMS_MASTER_KEY_ID }}
       - name: Lint with flake8
         run: flake8 tomodachi/ tests/
       - name: Run dummy service

--- a/tests/services/aws_sns_sqs_service_with_credentials_with_encryption_at_rest.py
+++ b/tests/services/aws_sns_sqs_service_with_credentials_with_encryption_at_rest.py
@@ -6,7 +6,6 @@ import uuid as uuid_
 from typing import Any, Dict, Set
 
 import tomodachi
-from tomodachi.discovery.aws_sns_registration import AWSSNSRegistration
 from tomodachi.envelope.json_base import JsonBase
 from tomodachi.transport.aws_sns_sqs import aws_sns_sqs, aws_sns_sqs_publish
 

--- a/tests/services/aws_sns_sqs_service_with_credentials_with_encryption_at_rest.py
+++ b/tests/services/aws_sns_sqs_service_with_credentials_with_encryption_at_rest.py
@@ -62,7 +62,7 @@ class AWSSNSSQSService(tomodachi.Service):
 
     @aws_sns_sqs(
         "encrypted-test-topic-filtered",
-        queue_name="encrypted-test-queue-filter-currency-{}".format(data_uuid),
+        queue_name="encrypted-test-queue-fc-{}".format(data_uuid),
         filter_policy={"currency": ["SEK", "EUR", "USD", "GBP", "CNY"]},
     )
     async def test_filter_policy_currency(
@@ -75,7 +75,7 @@ class AWSSNSSQSService(tomodachi.Service):
 
     @aws_sns_sqs(
         "encrypted-test-topic-filtered",
-        queue_name="encrypted-test-queue-filter-amount-{}".format(data_uuid),
+        queue_name="encrypted-test-queue-fa-{}".format(data_uuid),
         filter_policy={"currency": ["SEK", "EUR", "USD", "GBP", "CNY"], "amount": [{"numeric": [">=", 99.51]}]},
     )
     async def test_filter_policy_amount(
@@ -86,7 +86,7 @@ class AWSSNSSQSService(tomodachi.Service):
 
             self.check_closer()
 
-    @aws_sns_sqs("encrypted-test-topic-unique", queue_name="test-queue-{}".format(data_uuid))
+    @aws_sns_sqs("encrypted-test-topic-unique", queue_name="encrypted-test-queue-{}".format(data_uuid))
     async def test_specified_queue_name(self, data: Any, metadata: Any, service: Any) -> None:
         if data == self.data_uuid:
             if self.test_topic_specified_queue_name_data_received:
@@ -95,7 +95,7 @@ class AWSSNSSQSService(tomodachi.Service):
 
             self.check_closer()
 
-    @aws_sns_sqs("encrypted-test-topic-unique", queue_name="test-queue-{}".format(data_uuid))
+    @aws_sns_sqs("encrypted-test-topic-unique", queue_name="encrypted-test-queue-{}".format(data_uuid))
     async def test_specified_queue_name_again(self, data: Any, metadata: Any, service: Any) -> None:
         if data == self.data_uuid:
             if self.test_topic_specified_queue_name_data_received:

--- a/tests/services/aws_sns_sqs_service_with_credentials_with_encryption_at_rest.py
+++ b/tests/services/aws_sns_sqs_service_with_credentials_with_encryption_at_rest.py
@@ -1,0 +1,164 @@
+import asyncio
+import json
+import os
+import signal
+import uuid as uuid_
+from typing import Any, Dict, Set
+
+import tomodachi
+from tomodachi.discovery.aws_sns_registration import AWSSNSRegistration
+from tomodachi.envelope.json_base import JsonBase
+from tomodachi.transport.aws_sns_sqs import aws_sns_sqs, aws_sns_sqs_publish
+
+data_uuid = str(uuid_.uuid4())
+
+
+@tomodachi.service
+class AWSSNSSQSService(tomodachi.Service):
+    name = "test_aws_sns_sqs_encryption_at_rest"
+    log_level = "INFO"
+    message_envelope = JsonBase
+    options = {
+        "aws": {
+            "region_name": os.environ.get("TOMODACHI_TEST_AWS_REGION"),
+            "aws_access_key_id": os.environ.get("TOMODACHI_TEST_AWS_ACCESS_KEY_ID"),
+            "aws_secret_access_key": os.environ.get("TOMODACHI_TEST_AWS_ACCESS_SECRET"),
+        },
+        "aws_sns_sqs": {
+            "queue_name_prefix": os.environ.get("TOMODACHI_TEST_SQS_QUEUE_PREFIX"),
+            "topic_prefix": os.environ.get("TOMODACHI_TEST_SNS_TOPIC_PREFIX"),
+            "sns_kms_master_key_id": os.environ.get("TOMODACHI_TEST_SNS_KMS_MASTER_KEY_ID") or "invalid",
+            "sqs_kms_master_key_id": os.environ.get("TOMODACHI_TEST_SQS_KMS_MASTER_KEY_ID") or "invalid",
+            "sqs_kms_data_key_reuse_period": 300,
+        },
+    }
+    uuid = os.environ.get("TOMODACHI_TEST_SERVICE_UUID") or ""
+    closer: asyncio.Future = asyncio.Future()
+    test_topic_data_received = False
+    test_topic_specified_queue_name_data_received = False
+    test_topic_metadata_topic = None
+    test_topic_service_uuid = None
+    test_message_attribute_currencies: Set = set()
+    test_message_attribute_amounts: Set = set()
+    data_uuid = data_uuid
+
+    def check_closer(self) -> None:
+        if (
+            self.test_topic_data_received
+            and self.test_topic_specified_queue_name_data_received
+            and len(self.test_message_attribute_currencies) == 7
+            and len(self.test_message_attribute_amounts) == 2
+        ):
+            if not self.closer.done():
+                self.closer.set_result(None)
+
+    @aws_sns_sqs("encrypted-test-topic", competing=False)
+    async def test(self, data: Any, metadata: Any, service: Any) -> None:
+        if data == self.data_uuid:
+            self.test_topic_data_received = True
+            self.test_topic_metadata_topic = metadata.get("topic")
+            self.test_topic_service_uuid = service.get("uuid")
+
+            self.check_closer()
+
+    @aws_sns_sqs(
+        "encrypted-test-topic-filtered",
+        queue_name="encrypted-test-queue-filter-currency-{}".format(data_uuid),
+        filter_policy={"currency": ["SEK", "EUR", "USD", "GBP", "CNY"]},
+    )
+    async def test_filter_policy_currency(
+        self, data: Any, queue_url: str, receipt_handle: str, message_attributes: Dict
+    ) -> None:
+        if data == self.data_uuid and queue_url and receipt_handle:
+            self.test_message_attribute_currencies.add(json.dumps(message_attributes, sort_keys=True))
+
+            self.check_closer()
+
+    @aws_sns_sqs(
+        "encrypted-test-topic-filtered",
+        queue_name="encrypted-test-queue-filter-amount-{}".format(data_uuid),
+        filter_policy={"currency": ["SEK", "EUR", "USD", "GBP", "CNY"], "amount": [{"numeric": [">=", 99.51]}]},
+    )
+    async def test_filter_policy_amount(
+        self, data: Any, queue_url: str, receipt_handle: str, message_attributes: Dict
+    ) -> None:
+        if data == self.data_uuid and queue_url and receipt_handle:
+            self.test_message_attribute_amounts.add(json.dumps(message_attributes, sort_keys=True))
+
+            self.check_closer()
+
+    @aws_sns_sqs("encrypted-test-topic-unique", queue_name="test-queue-{}".format(data_uuid))
+    async def test_specified_queue_name(self, data: Any, metadata: Any, service: Any) -> None:
+        if data == self.data_uuid:
+            if self.test_topic_specified_queue_name_data_received:
+                raise Exception("test_topic_specified_queue_name_data_received already set")
+            self.test_topic_specified_queue_name_data_received = True
+
+            self.check_closer()
+
+    @aws_sns_sqs("encrypted-test-topic-unique", queue_name="test-queue-{}".format(data_uuid))
+    async def test_specified_queue_name_again(self, data: Any, metadata: Any, service: Any) -> None:
+        if data == self.data_uuid:
+            if self.test_topic_specified_queue_name_data_received:
+                raise Exception("test_topic_specified_queue_name_data_received already set")
+            self.test_topic_specified_queue_name_data_received = True
+
+            self.check_closer()
+
+    async def _started_service(self) -> None:
+        async def publish(data: Any, topic: str, **kwargs: Any) -> None:
+            await aws_sns_sqs_publish(self, data, topic=topic, wait=False, **kwargs)
+
+        async def _async() -> None:
+            async def sleep_and_kill() -> None:
+                await asyncio.sleep(30.0)
+                if not self.closer.done():
+                    self.closer.set_result(None)
+
+            task = asyncio.ensure_future(sleep_and_kill())
+            await self.closer
+            if not task.done():
+                task.cancel()
+            os.kill(os.getpid(), signal.SIGINT)
+
+        asyncio.ensure_future(_async())
+
+        async def _async_publisher() -> None:
+            await publish(self.data_uuid, "encrypted-test-topic")
+            await publish(self.data_uuid, "encrypted-test-topic-unique")
+
+            await publish(self.data_uuid, "encrypted-test-topic-filtered")
+            for ma in (
+                {},
+                {"currency": "DKK"},
+                {"currency": "sek"},
+                {"currency": ["SEK"], "amount": 1338, "value": "1338.00 SEK"},
+                {"value": "100 SEK"},
+                {"currency": "100 SEK"},
+                {"currency": "NOK"},
+                {"currency": "USD", "amount": 99.50, "value": "99.50 USD"},
+                {"amount": 4000},
+                {"currency": "EUR"},
+                {"currency": ["BTC", "ETH"]},
+                {"currency": ["JPY"]},
+                {"currency": ["GBP"]},
+                {"currency": "EUR"},
+                {"currency": "SEK", "amount": 4711},
+                {"currency": "SEK", "amount": 4711},
+                {"currency": "SEK", "amount": "9001.00"},
+                {"currency": ["CNY", "USD", "JPY"]},
+                {"currency": "EUR"},
+            ):
+                await publish(self.data_uuid, "encrypted-test-topic-filtered", message_attributes=ma)
+
+            for _ in range(10):
+                if self.test_topic_data_received:
+                    break
+                await publish(self.data_uuid, "encrypted-test-topic")
+                await asyncio.sleep(0.5)
+
+        asyncio.ensure_future(_async_publisher())
+
+    def stop_service(self) -> None:
+        if not self.closer.done():
+            self.closer.set_result(None)

--- a/tests/test_aws_sns_sqs_service_with_credentials_with_encryption_at_rest.py
+++ b/tests/test_aws_sns_sqs_service_with_credentials_with_encryption_at_rest.py
@@ -1,0 +1,62 @@
+import asyncio
+import json
+import os
+import time
+from typing import Any
+
+import pytest
+
+from run_test_service_helper import start_service
+
+
+@pytest.mark.skipif(
+    not os.environ.get("TOMODACHI_TEST_AWS_ACCESS_KEY_ID") or not os.environ.get("TOMODACHI_TEST_AWS_ACCESS_SECRET"),
+    reason="AWS configuration options missing in environment",
+)
+def test_start_aws_sns_sqs_service_with_credentials(monkeypatch: Any, capsys: Any, loop: Any) -> None:
+    services, future = start_service("tests/services/aws_sns_sqs_service_with_credentials_with_encryption_at_rest.py", monkeypatch)
+
+    assert services is not None
+    assert len(services) == 1
+    instance = services.get("test_aws_sns_sqs_encryption_at_rest")
+    assert instance is not None
+
+    assert instance.uuid is not None
+
+    async def _async(loop: Any) -> None:
+        loop_until = time.time() + 10
+        while loop_until > time.time():
+            if (
+                instance.test_topic_data_received
+                and instance.test_topic_metadata_topic
+                and instance.test_topic_service_uuid
+                and instance.test_topic_specified_queue_name_data_received
+                and len(instance.test_message_attribute_currencies) == 7
+                and len(instance.test_message_attribute_amounts) == 2
+            ):
+                break
+            await asyncio.sleep(0.5)
+
+        assert instance.test_topic_data_received
+        assert instance.test_topic_metadata_topic == "encrypted-test-topic"
+        assert instance.test_topic_service_uuid == instance.uuid
+        assert instance.test_topic_specified_queue_name_data_received
+        assert len(instance.test_message_attribute_currencies) == 7
+        assert len(instance.test_message_attribute_amounts) == 2
+        assert instance.test_message_attribute_currencies == {
+            json.dumps({"currency": "EUR"}),
+            json.dumps({"currency": ["GBP"]}),
+            json.dumps({"currency": ["CNY", "USD", "JPY"]}),
+            json.dumps({"currency": "SEK", "amount": 4711}, sort_keys=True),
+            json.dumps({"currency": ["SEK"], "amount": 1338, "value": "1338.00 SEK"}, sort_keys=True),
+            json.dumps({"currency": "SEK", "amount": "9001.00"}, sort_keys=True),
+            json.dumps({"currency": "USD", "amount": 99.50, "value": "99.50 USD"}, sort_keys=True),
+        }
+        assert instance.test_message_attribute_amounts == {
+            json.dumps({"currency": "SEK", "amount": 4711}, sort_keys=True),
+            json.dumps({"currency": ["SEK"], "amount": 1338, "value": "1338.00 SEK"}, sort_keys=True),
+        }
+
+    loop.run_until_complete(_async(loop))
+    instance.stop_service()
+    loop.run_until_complete(future)

--- a/tests/test_aws_sns_sqs_service_with_credentials_with_encryption_at_rest.py
+++ b/tests/test_aws_sns_sqs_service_with_credentials_with_encryption_at_rest.py
@@ -14,7 +14,9 @@ from run_test_service_helper import start_service
     reason="AWS configuration options missing in environment",
 )
 def test_start_aws_sns_sqs_service_with_credentials(monkeypatch: Any, capsys: Any, loop: Any) -> None:
-    services, future = start_service("tests/services/aws_sns_sqs_service_with_credentials_with_encryption_at_rest.py", monkeypatch)
+    services, future = start_service(
+        "tests/services/aws_sns_sqs_service_with_credentials_with_encryption_at_rest.py", monkeypatch
+    )
 
     assert services is not None
     assert len(services) == 1

--- a/tomodachi/container.py
+++ b/tomodachi/container.py
@@ -194,8 +194,12 @@ class ServiceContainer(object):
                 logging.getLogger("exception").exception("Uncaught exception: {}".format(str(e)))
 
             if started_futures and any(started_futures):
-                started_futures_result = await asyncio.wait([asyncio.ensure_future(func()) for func in started_futures if func])
-                exception = [v.exception() for v in [value for value in started_futures_result if value][0] if v.exception()]
+                started_futures_result = await asyncio.wait(
+                    [asyncio.ensure_future(func()) for func in started_futures if func]
+                )
+                exception = [
+                    v.exception() for v in [value for value in started_futures_result if value][0] if v.exception()
+                ]
                 if exception:
                     self.logger.warning("Failed to start service (exception raised in '_started_service')")
                     started_futures = set()

--- a/tomodachi/container.py
+++ b/tomodachi/container.py
@@ -194,7 +194,16 @@ class ServiceContainer(object):
                 logging.getLogger("exception").exception("Uncaught exception: {}".format(str(e)))
 
             if started_futures and any(started_futures):
-                await asyncio.wait([asyncio.ensure_future(func()) for func in started_futures if func])
+                started_futures_result = await asyncio.wait([asyncio.ensure_future(func()) for func in started_futures if func])
+                exception = [v.exception() for v in [value for value in started_futures_result if value][0] if v.exception()]
+                if exception:
+                    self.logger.warning("Failed to start service (exception raised in '_started_service')")
+                    started_futures = set()
+                    self.stop_service()
+                    try:
+                        raise cast(Exception, exception[0])
+                    except Exception as e:
+                        logging.getLogger("exception").exception("Uncaught exception: {}".format(str(e)))
         else:
             self.logger.warning("No transports defined in service file")
             self.stop_service()

--- a/tomodachi/transport/aws_sns_sqs.py
+++ b/tomodachi/transport/aws_sns_sqs.py
@@ -40,6 +40,7 @@ DRAIN_MESSAGE_PAYLOAD = "__TOMODACHI_DRAIN__cdab4416-1727-4603-87c9-0ff8dddf1f22
 MESSAGE_ENVELOPE_DEFAULT = "e6fb6007-cf15-4cfd-af2e-1d1683374e70"
 MESSAGE_PROTOCOL_DEFAULT = MESSAGE_ENVELOPE_DEFAULT  # deprecated
 MESSAGE_TOPIC_PREFIX = "09698c75-832b-470f-8e05-96d2dd8c4853"
+MESSAGE_TOPIC_ATTRIBUTES = "dc6c667f-4c22-4a63-85f6-3ea0c7e2db49"
 FILTER_POLICY_DEFAULT = "7e68632f-3b39-4293-b5a9-16644cf857a5"
 
 AnythingButFilterPolicyValueType = Union[str, int, float, List[str], List[int], List[float], List[Union[int, float]]]
@@ -132,6 +133,8 @@ class AWSSNSSQSTransport(Invoker):
         message_protocol: Any = MESSAGE_ENVELOPE_DEFAULT,  # deprecated
         topic_prefix: Optional[str] = MESSAGE_TOPIC_PREFIX,
         message_attributes: Optional[Dict[str, Any]] = None,
+        topic_attributes: Optional[Union[str, Dict[str, Union[bool, str]]]] = MESSAGE_TOPIC_ATTRIBUTES,
+        overwrite_topic_attributes: bool = False,
         **kwargs: Any,
     ) -> None:
         if message_envelope == MESSAGE_ENVELOPE_DEFAULT and message_protocol != MESSAGE_ENVELOPE_DEFAULT:
@@ -157,7 +160,7 @@ class AWSSNSSQSTransport(Invoker):
                     service, topic, data, message_attributes=message_attributes, **kwargs
                 )
 
-        topic_arn = await cls.create_topic(topic, service.context, topic_prefix)
+        topic_arn = await cls.create_topic(topic, service.context, topic_prefix, attributes=topic_attributes, overwrite_attributes=overwrite_topic_attributes)
 
         async def _publish_message() -> None:
             await cls.publish_message(topic_arn, payload, cast(Dict, message_attributes), service.context)
@@ -514,7 +517,7 @@ class AWSSNSSQSTransport(Invoker):
             raise AWSSNSSQSConnectionException(error_message, log_level=context.get("log_level")) from e
 
     @classmethod
-    async def create_topic(cls, topic: str, context: Dict, topic_prefix: Optional[str] = MESSAGE_TOPIC_PREFIX) -> str:
+    async def create_topic(cls, topic: str, context: Dict, topic_prefix: Optional[str] = MESSAGE_TOPIC_PREFIX, attributes: Optional[Union[str, Dict[str, Union[bool, str]]]] = MESSAGE_TOPIC_ATTRIBUTES, overwrite_attributes: bool = True) -> str:
         if not cls.topics:
             cls.topics = {}
         if cls.topics.get(topic):
@@ -525,12 +528,72 @@ class AWSSNSSQSTransport(Invoker):
         if not connector.get_client("tomodachi.sns"):
             await cls.create_client("sns", context)
 
+        config_base = context.get("options", {}).get("aws_sns_sqs", context.get("options", {}).get("aws", {}))
+        aws_config_base = context.get("options", {}).get("aws", {})
+
+        sns_kms_master_key_id: Optional[str] = None
+        for config_value in (
+            config_base.get("aws_sns_kms_master_key_id"),
+            config_base.get("sns_kms_master_key_id"),
+            aws_config_base.get("aws_sns_kms_master_key_id"),
+            aws_config_base.get("sns_kms_master_key_id"),
+            aws_config_base.get("aws_kms_master_key_id"),
+            aws_config_base.get("kms_master_key_id"),
+            config_base.get("aws_kms_master_key_id"),
+            config_base.get("kms_master_key_id"),
+        ):
+            if config_value is not None:
+                if isinstance(config_value, str) and config_value == "":
+                    sns_kms_master_key_id = ""
+                    break
+                elif isinstance(config_value, bool) and config_value is False:
+                    sns_kms_master_key_id = ""
+                    break
+                elif isinstance(config_value, str) and config_value:
+                    sns_kms_master_key_id = config_value
+                    break
+
+        topic_attributes: Dict
+
+        if attributes is None or attributes == MESSAGE_TOPIC_ATTRIBUTES:
+            topic_attributes = {}
+        elif not isinstance(attributes, dict):
+            raise Exception("Argument 'attributes' to 'AWSSNSSQSTransport.create_topic' should be specified as a dict mapping")
+        else:
+            topic_attributes = copy.deepcopy(attributes)
+
+        if sns_kms_master_key_id is not None and "KmsMasterKeyId" not in topic_attributes:
+            topic_attributes["KmsMasterKeyId"] = sns_kms_master_key_id
+
+        update_attributes = True if topic_attributes else False
+        topic_arn = None
+
         try:
             async with connector("tomodachi.sns", service_name="sns") as client:
                 response = await asyncio.wait_for(
-                    client.create_topic(Name=cls.encode_topic(cls.get_topic_name(topic, context, topic_prefix))),
+                    client.create_topic(Name=cls.encode_topic(cls.get_topic_name(topic, context, topic_prefix)), Attributes=topic_attributes),
                     timeout=40,
                 )
+                topic_arn = response.get("TopicArn")
+                update_attributes = False
+
+            if topic_attributes and topic_attributes.get("KmsMasterKeyId") == "":
+                try:
+                    async with connector("tomodachi.sns", service_name="sqs") as client:
+                        topic_attributes_response = await client.get_topic_attributes(TopicArn=topic_arn)
+                        if not topic_attributes_response.get("Attributes", {}).get("KmsMasterKeyId"):
+                            update_attributes = False
+                            overwrite_attributes = False
+                except Exception:
+                    pass
+
+                if overwrite_attributes:
+                    logging.getLogger("transport.aws_sns_sqs").info(
+                        "SNS topic attribute 'KmsMasterKeyId' on SNS topic '{}' will be updated to disable server-side encryption".format(
+                            topic_arn
+                        )
+                    )
+                    update_attributes = True
         except (botocore.exceptions.NoCredentialsError, aiohttp.client_exceptions.ClientOSError) as e:
             error_message = str(e)
             logging.getLogger("transport.aws_sns_sqs").warning(
@@ -543,12 +606,68 @@ class AWSSNSSQSTransport(Invoker):
             asyncio.TimeoutError,
         ) as e:
             error_message = str(e) if not isinstance(e, asyncio.TimeoutError) else "Network timeout"
-            logging.getLogger("transport.aws_sns_sqs").warning(
-                "Unable to create topic [sns] on AWS ({})".format(error_message)
-            )
-            raise AWSSNSSQSException(error_message, log_level=context.get("log_level")) from e
+            if "Topic already exists with different attributes" in error_message:
+                try:
+                    async with connector("tomodachi.sns", service_name="sns") as client:
+                        response = await asyncio.wait_for(
+                            client.create_topic(Name=cls.encode_topic(cls.get_topic_name(topic, context, topic_prefix))),
+                            timeout=40,
+                        )
+                        topic_arn = response.get("TopicArn")
+                except (
+                    Exception,
+                    asyncio.TimeoutError,
+                ) as e:
+                    error_message = str(e) if not isinstance(e, asyncio.TimeoutError) else "Network timeout"
+                    logging.getLogger("transport.aws_sns_sqs").warning(
+                        "Unable to create topic [sns] on AWS ({})".format(error_message)
+                    )
+                    raise AWSSNSSQSException(error_message, log_level=context.get("log_level")) from e
 
-        topic_arn = response.get("TopicArn")
+                logging.getLogger("transport.aws_sns_sqs").info(
+                    "Already existing SNS topic '{}' has different topic attributes".format(
+                        topic_arn
+                    )
+                )
+            else:
+                logging.getLogger("transport.aws_sns_sqs").warning(
+                    "Unable to create topic [sns] on AWS ({})".format(error_message)
+                )
+                raise AWSSNSSQSException(error_message, log_level=context.get("log_level")) from e
+
+        if update_attributes and topic_attributes and topic_arn and not overwrite_attributes:
+            logging.getLogger("transport.aws_sns_sqs").warning(
+                "Will not overwrite existing attributes on SNS topic '{}'".format(topic_arn)
+            )
+            update_attributes = False
+
+        if update_attributes and topic_attributes and topic_arn:
+            for attribute_name, attribute_value in topic_attributes.items():
+                try:
+                    logging.getLogger("transport.aws_sns_sqs").info(
+                        "Updating '{}' attribute on SNS topic '{}'".format(
+                            attribute_name, topic_arn
+                        )
+                    )
+                    async with connector("tomodachi.sns", service_name="sns") as client:
+                        await client.set_topic_attributes(
+                            TopicArn=topic_arn,
+                            AttributeName=attribute_name,
+                            AttributeValue=attribute_value,
+                        )
+                except (
+                    botocore.exceptions.NoCredentialsError,
+                    aiohttp.client_exceptions.ClientOSError,
+                    botocore.exceptions.PartialCredentialsError,
+                    botocore.exceptions.ClientError,
+                    asyncio.TimeoutError,
+                ) as e:
+                    error_message = str(e)
+                    logging.getLogger("transport.aws_sns_sqs").warning(
+                        "Unable to create topic [sns] on AWS ({})".format(error_message)
+                    )
+                    raise AWSSNSSQSException(error_message, log_level=context.get("log_level")) from e
+
         if not topic_arn or not isinstance(topic_arn, str):
             error_message = "Missing ARN in response"
             logging.getLogger("transport.aws_sns_sqs").warning(
@@ -1264,6 +1383,9 @@ class AWSSNSSQSTransport(Invoker):
                     queue_name = cls.prefix_queue_name(queue_name, context)
 
                 queue_url, queue_arn = await cls.create_queue(queue_name, context)
+
+                topic_attributes: Optional[Union[str, Dict[str, Union[bool, str]]]] = MESSAGE_TOPIC_ATTRIBUTES,
+                overwrite_topic_attributes: bool = False,
 
                 if re.search(r"([*#])", topic):
                     await cls.subscribe_wildcard_topic(topic, queue_arn, queue_url, context, attributes=attributes)


### PR DESCRIPTION
Encryption at rest for AWS SNS and/or AWS SQS which can optionally be configured by specifying the KMS key alias or KMS key id as a tomodachi service option ``options.aws_sns_sqs.sns_kms_master_key_id`` (to configure encryption at rest on the SNS topics for which the tomodachi service handles the SNS -> SQS subscriptions) and/or ``options.aws_sns_sqs.sqs_kms_master_key_id`` (to configure encryption at rest for the SQS queues which the service is consuming). 

Note that an option value set to empty string (``""``) or ``False`` will unset the KMS master key id and thus disable encryption at rest. (The AWS APIs for SNS and SQS uses empty string value to the KMSMasterKeyId attribute to disable encryption with KMS if it was previously enabled).

If instead an option is completely unset or set to ``None`` value no changes will be done to the KMS related attributes on an existing topic or queue. 

If it's expected that the services themselves, via their IAM credentials or assumed role, are responsible for creating queues and topics, these options could be used to provide encryption at rest without additional manual intervention 

*However, do not use these options if you instead are using IaC tooling to handle the topics, queues and subscriptions or that they for example are created / updated as a part of deployments. To not have the service update any attributes keep the options unset or set to a ``None`` value.* 

AWS documentation:
* https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html
* https://docs.aws.amazon.com/sns/latest/dg/sns-server-side-encryption.html#sse-key-terms.