### PR TITLE
Allows functions decorated with the @aws_sns_sqs invoker decorator to not specify the topic

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,10 @@ Changes
   sub directory of the current working directory + the directory of the
   started service (or services) were monitored.
 
+- The ``topic`` argument to the ``@tomodachi.aws_sns_sqs`` decorator is
+  now optional, which is useful if subscribing to a SQS queue where the SNS
+  topic or the topic subscriptions are set up apart from the service code,
+  for example during deployment or as infra.
 
 0.21.4 (2021-07-26)
 -------------------

--- a/README.rst
+++ b/README.rst
@@ -526,8 +526,8 @@ HTTP endpoints:
 
 AWS SNS+SQS messaging:
 ----------------------
-``@tomodachi.aws_sns_sqs(topic, competing=True, queue_name=None, filter_policy=None, **kwargs)``
-  This would set up an **AWS SQS queue**, subscribing to messages on the **AWS SNS topic** ``topic``, whereafter it will start consuming messages from the queue.
+``@tomodachi.aws_sns_sqs(topic=None, competing=True, queue_name=None, filter_policy=None, **kwargs)``
+  This would set up an **AWS SQS queue**, subscribing to messages on the **AWS SNS topic** ``topic`` (if a ``topic`` is specified), whereafter it will start consuming messages from the queue.
 
   The ``competing`` value is used when the same queue name should be used for several services of the same type and thus "compete" for who should consume the message. Since ``tomodachi`` version 0.19.x this value has a changed default value and will now default to ``True`` as this is the most likely use-case for pub/sub in distributed architectures.
 


### PR DESCRIPTION
Useful if subscribing to a SQS queue where the SNS topic or the topic subscriptions are set up apart from the service code, for example during deployment or as infra.

Should also suffice to solve what is expected within https://github.com/kalaspuff/tomodachi/issues/1488.