### PR TITLE
Pin the version of tzlocal to not use the 3.0 release as tomodachi is using the tz .localize functionality

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ python = "^3.7"
 
 aioamqp = ">=0.13.0, <0.15.0"
 aiobotocore = ">=0.10.4, <2.0.0"
-tzlocal = ">=1.4"
+tzlocal = ">=1.4,<3.0"
 pytz = "*"
 cchardet = ">=2.1.6"
 aiohttp = ">=3.5.4, <3.8.0"


### PR DESCRIPTION
Fixes https://github.com/kalaspuff/tomodachi/issues/1504