### PR TITLE
Add shutdown signal function

### DIFF
--- a/tests/services/start_process_service_schedule.py
+++ b/tests/services/start_process_service_schedule.py
@@ -43,5 +43,8 @@ class SchedulerService(tomodachi.Service):
         if not self.closer.done():
             self.closer.set_result(None)
 
+    async def _stopping_service(self) -> None:
+        self.function_order.append("_stopping_service")
+
     async def _stop_service(self) -> None:
         self.function_order.append("_stop_service")

--- a/tests/test_start_process_schedule.py
+++ b/tests/test_start_process_schedule.py
@@ -27,5 +27,6 @@ def test_start_process_schedule(monkeypatch: Any, capsys: Any, loop: Any) -> Non
         "every_fifth_second",
         "every_fifth_second",
         "stop_service",
+        "_stopping_service",
         "_stop_service",
     ]

--- a/tomodachi/container.py
+++ b/tomodachi/container.py
@@ -184,6 +184,7 @@ class ServiceContainer(object):
                             await registry._register_service(instance)
 
                     started_futures.add(getattr(instance, "_started_service", None))
+                    stop_futures.add(getattr(instance, "_stopping_service", None))
                     stop_futures.add(getattr(instance, "_stop_service", None))
 
                     self.logger.info('Started service "{}" [id: {}]'.format(name, instance.uuid))


### PR DESCRIPTION
# Changes
Adds the possibility to add a function called `_stopping_service` to the tomodachi Service class, which is run as soon as a termination signal is received by the service.
This would be useful for cleaning up-/sending a `cancel` command to tasks not handled via HTTP/AMQP.

## Testing
• Added the function to a test case and an assertion that it is run in the correct order.
• Ran `make tests`
• Tested locally with own service instance, triggering by hitting sending `SIGINT` and `SIGTERM` to the service in question.