### PR TITLE
Rely on client name for reconnection instead of just using the client object

### DIFF
--- a/tomodachi/helpers/aiobotocore_connector.py
+++ b/tomodachi/helpers/aiobotocore_connector.py
@@ -240,9 +240,11 @@ class ClientConnector(object):
                     raise
                 await asyncio.sleep(0.1)
 
-        if not self.get_client(alias_name or service_name or ""):
+        client_name = alias_name or service_name or ""
+
+        if not self.get_client(client_name):
             await self.create_client(alias_name, credentials, service_name)
-        client = self.get_client(alias_name or service_name or "")
+        client = self.get_client(client_name)
 
         try:
             yield client
@@ -254,7 +256,7 @@ class ClientConnector(object):
             await self.close_client(client=client, fast=True)
             raise
         except (aiohttp.client_exceptions.ServerDisconnectedError, asyncio.TimeoutError, RuntimeError):
-            await self.reconnect_client(client=client)
+            await self.reconnect_client(client_name, client=client)
             raise
         except botocore.exceptions.ClientError as e:
             error_message = str(e)


### PR DESCRIPTION
Fix for potential exceptions on `botocore` session client raising a `RuntimeError`, resulting in a `tomodachi` _"Client has never been created in the first place_" exception on reconnection to the AWS API.