### PR TITLE
Added google.protobuf.message to list of safe modules to not unload on reloads

### DIFF
--- a/tomodachi/helpers/safe_modules.py
+++ b/tomodachi/helpers/safe_modules.py
@@ -322,6 +322,7 @@ SAFE_MODULES = {
     "gettext",
     "google",
     "google.protobuf",
+    "google.protobuf.message",
     "grp",
     "hashlib",
     "heapq",


### PR DESCRIPTION
Fixes an issue with live reloading on code changes which in same cases would trigger a repeated `A Message class can only inherit from Message` TypeError, preventing the service to restart correctly.