### PR TITLE
Add support for FIFO topics and queues

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -589,7 +589,7 @@ AWS SNS+SQS messaging:
         visibility_timeout=VISIBILITY_TIMEOUT_DEFAULT,
         dead_letter_queue_name=DEAD_LETTER_QUEUE_DEFAULT,
         max_receive_count=MAX_RECEIVE_COUNT_DEFAULT,
-        fifo=True,
+        fifo=False,
         **kwargs,
     )
 

--- a/README.rst
+++ b/README.rst
@@ -589,6 +589,7 @@ AWS SNS+SQS messaging:
         visibility_timeout=VISIBILITY_TIMEOUT_DEFAULT,
         dead_letter_queue_name=DEAD_LETTER_QUEUE_DEFAULT,
         max_receive_count=MAX_RECEIVE_COUNT_DEFAULT,
+        fifo=True,
         **kwargs,
     )
 
@@ -598,6 +599,8 @@ Usage:
   The ``competing`` value is used when the same queue name should be used for several services of the same type and thus "compete" for who should consume the message. Since ``tomodachi`` version 0.19.x this value has a changed default value and will now default to ``True`` as this is the most likely use-case for pub/sub in distributed architectures.
 
   Unless ``queue_name`` is specified an auto generated queue name will be used. Additional prefixes to both ``topic`` and ``queue_name`` can be assigned by setting the ``options.aws_sns_sqs.topic_prefix`` and ``options.aws_sns_sqs.queue_name_prefix`` dict values.
+
+  AWS supports two types of queues and topics, namely ``standard`` and ``FIFO``. The major difference between these is that the latter guarantees correct ordering and at-most-once delivery. By default, tomodachi creates ``standard`` queues and topics. To create them as ``FIFO`` instead, set ``fifo`` to ``True``.
 
   The ``filter_policy`` value of specified as a keyword argument will be applied on the SNS subscription (for the specified topic and queue) as the ``"FilterPolicy`` attribute. This will apply a filter on SNS messages using the chosen "message attributes" and/or their values specified in the filter. Make note that the filter policy dict structure differs somewhat from the actual message attributes, as values to the keys in the filter policy must be a dict (object) or list (array). Example: A filter policy value of ``{"event": ["order_paid"], "currency": ["EUR", "USD"]}`` would set up the SNS subscription to receive messages on the topic only where the message attribute ``"event"`` is ``"order_paid"`` and the ``"currency"`` value is either ``"EUR"`` or ``"USD"``.
 

--- a/examples/basic_examples/aws_sns_sqs_fifo_service.py
+++ b/examples/basic_examples/aws_sns_sqs_fifo_service.py
@@ -7,8 +7,6 @@ from tomodachi.discovery import AWSSNSRegistration
 from tomodachi.envelope import JsonBase
 from tomodachi.transport.aws_sns_sqs import AWSSNSSQSInternalServiceError
 
-failed = False
-
 
 class ExampleAWSSNSSQSService(tomodachi.Service):
     name = "example-aws-sns-sqs-fifo-service"

--- a/examples/basic_examples/aws_sns_sqs_fifo_service.py
+++ b/examples/basic_examples/aws_sns_sqs_fifo_service.py
@@ -1,0 +1,51 @@
+import os
+from typing import Any
+
+import tomodachi
+from tomodachi import aws_sns_sqs, aws_sns_sqs_publish
+from tomodachi.discovery import AWSSNSRegistration
+from tomodachi.envelope import JsonBase
+from tomodachi.transport.aws_sns_sqs import AWSSNSSQSInternalServiceError
+
+failed = False
+
+
+class ExampleAWSSNSSQSService(tomodachi.Service):
+    name = "example-aws-sns-sqs-fifo-service"
+    log_level = "INFO"
+    discovery = [AWSSNSRegistration]
+    uuid = str(os.environ.get("SERVICE_UUID") or "")
+
+    # The message envelope class defines how a message should be processed when sent and received
+    # See tomodachi/envelope/json_base.py for a basic example using JSON and transferring some metadata
+    message_envelope = JsonBase
+
+    # Some options can be specified to define credentials, used ports, hostnames, access log, etc.
+    options = {
+        "aws_sns_sqs.region_name": None,  # specify AWS region (example: 'eu-west-1')
+        "aws_sns_sqs.aws_access_key_id": None,  # specify AWS access key (example: 'AKIAXNTIENCJIY2STOCI')
+        "aws_sns_sqs.aws_secret_access_key": None,  # specify AWS secret key (example: 'f7sha92hNotarealsecretkeyn29ShnSYQi3nzgA')
+        "aws_endpoint_urls.sns": None,  # For example 'http://localhost:4575' if localstack is used for testing
+        "aws_endpoint_urls.sqs": None,  # For example 'http://localhost:4576' if localstack is used for testing
+    }
+
+    failed: bool
+
+    @aws_sns_sqs("example-fifo-route-1", queue_name="test-fifo-queue.fifo", fifo=True)
+    async def route(self, data: Any) -> None:
+        self.log('Received data (function: route) - "{}"'.format(data))
+        if data == "2" and not self.failed:
+            self.log("Failing the message on purpose")
+            self.failed = True
+            raise AWSSNSSQSInternalServiceError("boom")
+
+    async def _started_service(self) -> None:
+        async def publish(data: Any, topic: str, group_id: str) -> None:
+            self.log('Publish data "{}"'.format(data))
+            await aws_sns_sqs_publish(self, data, topic=topic, group_id=group_id)
+
+        self.failed = False
+
+        await publish("1", "example-fifo-route-1", "group-1")
+        await publish("2", "example-fifo-route-1", "group-1")
+        await publish("3", "example-fifo-route-1", "group-1")

--- a/tests/test_aws_sns_sqs_service_with_credentials.py
+++ b/tests/test_aws_sns_sqs_service_with_credentials.py
@@ -24,7 +24,7 @@ def test_start_aws_sns_sqs_service_with_credentials(monkeypatch: Any, capsys: An
     assert instance.uuid is not None
 
     async def _async(loop: Any) -> None:
-        loop_until = time.time() + 10
+        loop_until = time.time() + 90
         while loop_until > time.time():
             if (
                 instance.test_topic_data_received
@@ -33,6 +33,7 @@ def test_start_aws_sns_sqs_service_with_credentials(monkeypatch: Any, capsys: An
                 and instance.test_topic_specified_queue_name_data_received
                 and len(instance.test_message_attribute_currencies) == 7
                 and len(instance.test_message_attribute_amounts) == 2
+                and len(instance.test_fifo_messages) == 3
             ):
                 break
             await asyncio.sleep(0.5)
@@ -56,6 +57,8 @@ def test_start_aws_sns_sqs_service_with_credentials(monkeypatch: Any, capsys: An
             json.dumps({"currency": "SEK", "amount": 4711}, sort_keys=True),
             json.dumps({"currency": ["SEK"], "amount": 1338, "value": "1338.00 SEK"}, sort_keys=True),
         }
+        assert instance.test_fifo_failed
+        assert instance.test_fifo_messages == ["1", "2", "3"]
 
     loop.run_until_complete(_async(loop))
     instance.stop_service()

--- a/tests/test_aws_sns_sqs_transport.py
+++ b/tests/test_aws_sns_sqs_transport.py
@@ -5,20 +5,30 @@ from typing import Any
 import pytest
 
 from run_test_service_helper import start_service
-from tomodachi.transport.aws_sns_sqs import AWSSNSSQSException, AWSSNSSQSTransport
+from tomodachi.transport.aws_sns_sqs import AWSSNSSQSException, AWSSNSSQSTransport, str_to_bool
 
 
-def test_topic_name(monkeypatch: Any) -> None:
-    topic_name = AWSSNSSQSTransport.get_topic_name("test-topic", {})
+def test_get_standard_topic_name(monkeypatch: Any) -> None:
+    topic_name = AWSSNSSQSTransport.get_topic_name("test-topic", {}, fifo=False)
     assert topic_name == "test-topic"
 
     topic_name = AWSSNSSQSTransport.get_topic_name(
-        "test-topic", {"options": {"aws_sns_sqs": {"topic_prefix": "prefix-"}}}
+        "test-topic", {"options": {"aws_sns_sqs": {"topic_prefix": "prefix-"}}}, fifo=False
     )
     assert topic_name == "prefix-test-topic"
 
 
-def test_encode_topic(monkeypatch: Any) -> None:
+def test_get_fifo_topic_name(monkeypatch: Any) -> None:
+    topic_name = AWSSNSSQSTransport.get_topic_name("test-topic", {}, fifo=True)
+    assert topic_name == "test-topic.fifo"
+
+    topic_name = AWSSNSSQSTransport.get_topic_name(
+        "test-topic", {"options": {"aws_sns_sqs": {"topic_prefix": "prefix-"}}}, fifo=True
+    )
+    assert topic_name == "prefix-test-topic.fifo"
+
+
+def test_encode_standard_topic(monkeypatch: Any) -> None:
     topic_name = AWSSNSSQSTransport.encode_topic("test-topic")
     assert topic_name == "test-topic"
 
@@ -26,7 +36,15 @@ def test_encode_topic(monkeypatch: Any) -> None:
     assert topic_name == "test___2e_topic"
 
 
-def test_decode_topic(monkeypatch: Any) -> None:
+def test_encode_fifo_topic(monkeypatch: Any) -> None:
+    topic_name = AWSSNSSQSTransport.encode_topic("test-topic.fifo")
+    assert topic_name == "test-topic.fifo"
+
+    topic_name = AWSSNSSQSTransport.encode_topic("test.topic.fifo")
+    assert topic_name == "test___2e_topic.fifo"
+
+
+def test_decode_standard_topic(monkeypatch: Any) -> None:
     topic_name = AWSSNSSQSTransport.decode_topic("test-topic")
     assert topic_name == "test-topic"
 
@@ -34,29 +52,82 @@ def test_decode_topic(monkeypatch: Any) -> None:
     assert topic_name == "test.topic"
 
 
-def test_queue_name(monkeypatch: Any) -> None:
+def test_decode_fifo_topic(monkeypatch: Any) -> None:
+    topic_name = AWSSNSSQSTransport.decode_topic("test-topic.fifo")
+    assert topic_name == "test-topic.fifo"
+
+    topic_name = AWSSNSSQSTransport.decode_topic("test___2e_topic.fifo")
+    assert topic_name == "test.topic.fifo"
+
+
+def test_get_standard_queue_name(monkeypatch: Any) -> None:
     _uuid = "5d0b530f-5c44-4981-b01f-342801bd48f5"
-    queue_name = AWSSNSSQSTransport.get_queue_name("test-topic", "func", _uuid, False, {})
+    queue_name = AWSSNSSQSTransport.get_queue_name("test-topic", "func", _uuid, False, {}, fifo=False)
     assert queue_name == "45b56d76d14276da54c0ef65ca5c604ab9d0301bbebf4d6ad11e91dd496c2975"
 
-    queue_name = AWSSNSSQSTransport.get_queue_name("test-topic", "func2", _uuid, False, {})
+    queue_name = AWSSNSSQSTransport.get_queue_name("test-topic", "func2", _uuid, False, {}, fifo=False)
     assert queue_name != "45b56d76d14276da54c0ef65ca5c604ab9d0301bbebf4d6ad11e91dd496c2975"
 
     queue_name = AWSSNSSQSTransport.get_queue_name(
-        "test-topic", "func", _uuid, False, {"options": {"aws_sns_sqs": {"queue_name_prefix": "prefix-"}}}
+        "test-topic",
+        "func",
+        _uuid,
+        False,
+        {"options": {"aws_sns_sqs": {"queue_name_prefix": "prefix-"}}},
+        fifo=False,
     )
     assert queue_name == "prefix-45b56d76d14276da54c0ef65ca5c604ab9d0301bbebf4d6ad11e91dd496c2975"
 
-    queue_name = AWSSNSSQSTransport.get_queue_name("test-topic", "func", _uuid, True, {})
+    queue_name = AWSSNSSQSTransport.get_queue_name("test-topic", "func", _uuid, True, {}, fifo=False)
     assert queue_name == "c6fb053c1b70aabd10bfefd087166b532b7c79ed12d24f2d43a9999c724797fd"
 
-    queue_name = AWSSNSSQSTransport.get_queue_name("test-topic", "func2", _uuid, True, {})
+    queue_name = AWSSNSSQSTransport.get_queue_name("test-topic", "func2", _uuid, True, {}, fifo=False)
     assert queue_name == "c6fb053c1b70aabd10bfefd087166b532b7c79ed12d24f2d43a9999c724797fd"
 
     queue_name = AWSSNSSQSTransport.get_queue_name(
-        "test-topic", "func", _uuid, True, {"options": {"aws_sns_sqs": {"queue_name_prefix": "prefix-"}}}
+        "test-topic",
+        "func",
+        _uuid,
+        True,
+        {"options": {"aws_sns_sqs": {"queue_name_prefix": "prefix-"}}},
+        fifo=False,
     )
     assert queue_name == "prefix-c6fb053c1b70aabd10bfefd087166b532b7c79ed12d24f2d43a9999c724797fd"
+
+
+def test_get_fifo_queue_name(monkeypatch: Any) -> None:
+    _uuid = "5d0b530f-5c44-4981-b01f-342801bd48f5"
+    queue_name = AWSSNSSQSTransport.get_queue_name("test-topic.fifo", "func", _uuid, False, {}, fifo=True)
+    assert queue_name == "ad38a445b6b80e599dfff888caf6806f300ad3f565a8906b38176003b913f893.fifo"
+
+    queue_name = AWSSNSSQSTransport.get_queue_name("test-topic.fifo", "func2", _uuid, False, {}, fifo=True)
+    assert queue_name != "4276da54c0ef65ca5c604ab9d0301bbebf4d6ad11e91dd496c2975.fifo"
+
+    queue_name = AWSSNSSQSTransport.get_queue_name(
+        "test-topic.fifo",
+        "func",
+        _uuid,
+        False,
+        {"options": {"aws_sns_sqs": {"queue_name_prefix": "prefix-"}}},
+        fifo=True,
+    )
+    assert queue_name == "prefix-ad38a445b6b80e599dfff888caf6806f300ad3f565a8906b38176003b913f893.fifo"
+
+    queue_name = AWSSNSSQSTransport.get_queue_name("test-topic.fifo", "func", _uuid, True, {}, fifo=True)
+    assert queue_name == "1183df5a6172224209951ac7251ea9bdab277dbe988cde334fd30f84144cafeb.fifo"
+
+    queue_name = AWSSNSSQSTransport.get_queue_name("test-topic.fifo", "func2", _uuid, True, {}, fifo=True)
+    assert queue_name == "1183df5a6172224209951ac7251ea9bdab277dbe988cde334fd30f84144cafeb.fifo"
+
+    queue_name = AWSSNSSQSTransport.get_queue_name(
+        "test-topic.fifo",
+        "func",
+        _uuid,
+        True,
+        {"options": {"aws_sns_sqs": {"queue_name_prefix": "prefix-"}}},
+        fifo=True,
+    )
+    assert queue_name == "prefix-1183df5a6172224209951ac7251ea9bdab277dbe988cde334fd30f84144cafeb.fifo"
 
 
 def test_publish_invalid_credentials(monkeypatch: Any, capsys: Any, loop: Any) -> None:
@@ -79,3 +150,13 @@ def test_publish_invalid_credentials(monkeypatch: Any, capsys: Any, loop: Any) -
     out, err = capsys.readouterr()
     assert "The security token included in the request is invalid" in err
     assert out == ""
+
+
+@pytest.mark.parametrize("test_input,expected", [("true", True), ("TRUE", True), ("false", False), ("FALSE", False)])
+def test_str_to_bool_handles_correct_input(test_input: str, expected: bool) -> None:
+    assert str_to_bool(test_input) is expected
+
+
+def test_str_to_bool_handles_incorrect_input() -> None:
+    with pytest.raises(ValueError, match="'foobar' is not a valid boolean"):
+        str_to_bool("foobar")

--- a/tests/test_aws_sns_sqs_transport.py
+++ b/tests/test_aws_sns_sqs_transport.py
@@ -5,7 +5,7 @@ from typing import Any
 import pytest
 
 from run_test_service_helper import start_service
-from tomodachi.transport.aws_sns_sqs import AWSSNSSQSException, AWSSNSSQSTransport, str_to_bool
+from tomodachi.transport.aws_sns_sqs import AWSSNSSQSException, AWSSNSSQSTransport
 
 
 def test_get_standard_topic_name(monkeypatch: Any) -> None:
@@ -150,13 +150,3 @@ def test_publish_invalid_credentials(monkeypatch: Any, capsys: Any, loop: Any) -
     out, err = capsys.readouterr()
     assert "The security token included in the request is invalid" in err
     assert out == ""
-
-
-@pytest.mark.parametrize("test_input,expected", [("true", True), ("TRUE", True), ("false", False), ("FALSE", False)])
-def test_str_to_bool_handles_correct_input(test_input: str, expected: bool) -> None:
-    assert str_to_bool(test_input) is expected
-
-
-def test_str_to_bool_handles_incorrect_input() -> None:
-    with pytest.raises(ValueError, match="'foobar' is not a valid boolean"):
-        str_to_bool("foobar")


### PR DESCRIPTION
Adds basic support for FIFO queues & topics, which will be very helpful for the use cases where one needs guaranteed ordering of the messages. I could not come up with any nicer way of adding this functionality, so feel free to suggest alternatives if there are any.