### PR TITLE
Retries on SNS.Publish + SQS.DeleteMessage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,28 @@
 Changes
 =======
 
+0.24.3 (2023-xx-xx)
+-------------------
+- Fixes an issue in the internal retry logic when using ``aws_sns_sqs_publish``
+  if calls to the AWS API ``SNS.Publish`` would intermittently respond with 408
+  response without any body, which previously would've resulted in a
+  ``AWSSNSSQSException("Missing MessageId in response")`` immediately without
+  retries.
+
+  The publish function will now catch exceptions from ``botocore`` of type
+  ``ResponseParserError`` to which ``botocore`` has added that
+  ``"Further retries may succeed"``. ``tomodachi`` will retry such
+  ``SNS.Publish`` calls up to 3 times and if after all retries the library will
+  reraise the exception from ``botocore``.
+
+  It seems that ``botocore`` does not automatically retry such errors itself.
+
+- Similar to the above, the same kind of retries will now also be done during
+  AWS API calls for ``SQS.DeleteMessage``, where the
+  ``botocore.parser.QueryParser`` would raise an ``ResponseParserError`` exception
+  on 408 responses without body.
+
+
 0.24.2 (2023-06-13)
 -------------------
 - Fixes typing syntax for compatibility with Python 3.8 and Python 3.9 to solve the

--- a/tomodachi/transport/aws_sns_sqs.py
+++ b/tomodachi/transport/aws_sns_sqs.py
@@ -850,10 +850,11 @@ class AWSSNSSQSTransport(Invoker):
                     )
                     raise AWSSNSSQSException(error_message, log_level=context.get("log_level")) from e
                 continue
-            # SNS sometimes sends empty response with 408 errors
+            # AWS API can respond with empty body as 408 error - botocore adds "Further retries may succeed"
             except ResponseParserError as e:
                 if retry >= 3 or "Further retries may succeed" not in str(e):
                     raise e
+                continue
             break
 
         message_id = response.get("MessageId")

--- a/tomodachi/transport/aws_sns_sqs.py
+++ b/tomodachi/transport/aws_sns_sqs.py
@@ -904,6 +904,11 @@ class AWSSNSSQSTransport(Invoker):
                         )
                         raise AWSSNSSQSException(error_message, log_level=context.get("log_level")) from e
                     continue
+                # AWS API can respond with empty body as 408 error - botocore adds "Further retries may succeed"
+                except ResponseParserError as e:
+                    if retry >= 4 or "Further retries may succeed" not in str(e):
+                        raise e
+                    continue
                 break
 
         await _delete_message()


### PR DESCRIPTION
* Fixes an issue in the internal retry logic when using `aws_sns_sqs_publish` if calls to the AWS API `SNS.Publish` would intermittently respond with 408 response without any body, which previously would've resulted in a `AWSSNSSQSException("Missing MessageId in response")` immediately without retries. 
  
  This was previously attempted to be fixed in https://github.com/kalaspuff/tomodachi/pull/1664, but due to a missing `continue` statement it fell through to become an exception with the `"Missing MessageId in response"` message instead.

  The publish function will now catch exceptions from `botocore` of type `ResponseParserError` to which `botocore` has added that `"Further retries may succeed"`. `tomodachi` will retry such `SNS.Publish` calls up to 3 times and if after all retries the library will reraise the exception from `botocore`.

  It seems that `botocore` does not automatically retry such errors itself.

* Similar to the above, the same kind of retries will now also be done during AWS API calls for `SQS.DeleteMessage`, where the `botocore.parser.QueryParser` would raise an `ResponseParserError` exception on 408 responses without body.