### PR TITLE
Makes the publishing function return the message_id of the SNS message (or a task which can be awaited to get the message_id)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,10 @@ Changes
   numerous times due to thousands of messages simultanously being published to
   a topic that were previously unknown to the service.
 
+- The ``aws_sns_sqs_publish`` function will now return the SNS message identifier
+  as a ``str`` value if it is called with ``wait=True`` (default), or instead
+  return an ``asyncio.Task`` object if called with ``wait=False``.
+
 - Function handlers, middlewares and envelopes can all now specify additional
   keyword arguments in their signatures and receive transport centric values.
 

--- a/examples/basic_examples/aws_sns_sqs_middleware_service.py
+++ b/examples/basic_examples/aws_sns_sqs_middleware_service.py
@@ -229,7 +229,13 @@ class ExampleAWSSNSSQSService(tomodachi.Service):
             if not message_attributes:
                 message_attributes = {}
             self.log("publish -- sns.publish(data='{}', message_attributes={})".format(data, message_attributes))
-            await aws_sns_sqs_publish(self, data, topic=topic, message_attributes=message_attributes, wait=False)
+            await aws_sns_sqs_publish(
+                self,
+                data,
+                topic=topic,
+                message_attributes=message_attributes,
+                wait=False,
+            )
 
         await publish("a simple message", "example-route")
         await publish("a message with additional attribute", "example-route", message_attributes={"initial_a_value": 5})

--- a/tomodachi/transport/aws_sns_sqs.py
+++ b/tomodachi/transport/aws_sns_sqs.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import base64
 import binascii

--- a/tomodachi/transport/aws_sns_sqs.py
+++ b/tomodachi/transport/aws_sns_sqs.py
@@ -28,6 +28,7 @@ from typing import (
     TypedDict,
     Union,
     cast,
+    overload,
 )
 
 import aiobotocore
@@ -145,6 +146,48 @@ class AWSSNSSQSTransport(Invoker):
     topics: Optional[Dict[str, str]] = None
     close_waiter: Optional[asyncio.Future] = None
 
+    @overload
+    @classmethod
+    async def publish(
+        cls,
+        service: Any,
+        data: Any,
+        topic: str,
+        wait: Literal[True] = True,
+        *,
+        message_envelope: Any = MESSAGE_ENVELOPE_DEFAULT,
+        message_protocol: Any = MESSAGE_ENVELOPE_DEFAULT,  # deprecated
+        topic_prefix: Optional[str] = MESSAGE_TOPIC_PREFIX,
+        message_attributes: Optional[Dict[str, Any]] = None,
+        topic_attributes: Optional[Union[str, Dict[str, Union[bool, str]]]] = MESSAGE_TOPIC_ATTRIBUTES,
+        overwrite_topic_attributes: bool = False,
+        group_id: Optional[str] = None,
+        deduplication_id: Optional[str] = None,
+        **kwargs: Any,
+    ) -> str:
+        ...
+
+    @overload
+    @classmethod
+    async def publish(
+        cls,
+        service: Any,
+        data: Any,
+        topic: str,
+        wait: Literal[False],
+        *,
+        message_envelope: Any = MESSAGE_ENVELOPE_DEFAULT,
+        message_protocol: Any = MESSAGE_ENVELOPE_DEFAULT,  # deprecated
+        topic_prefix: Optional[str] = MESSAGE_TOPIC_PREFIX,
+        message_attributes: Optional[Dict[str, Any]] = None,
+        topic_attributes: Optional[Union[str, Dict[str, Union[bool, str]]]] = MESSAGE_TOPIC_ATTRIBUTES,
+        overwrite_topic_attributes: bool = False,
+        group_id: Optional[str] = None,
+        deduplication_id: Optional[str] = None,
+        **kwargs: Any,
+    ) -> asyncio.Task[str]:
+        ...
+
     @classmethod
     async def publish(
         cls,
@@ -162,7 +205,7 @@ class AWSSNSSQSTransport(Invoker):
         group_id: Optional[str] = None,
         deduplication_id: Optional[str] = None,
         **kwargs: Any,
-    ) -> None:
+    ) -> Union[str, asyncio.Task[str]]:
         if message_envelope == MESSAGE_ENVELOPE_DEFAULT and message_protocol != MESSAGE_ENVELOPE_DEFAULT:
             # Fallback if deprecated message_protocol keyword is used
             message_envelope = message_protocol
@@ -195,8 +238,8 @@ class AWSSNSSQSTransport(Invoker):
             overwrite_attributes=overwrite_topic_attributes,
         )
 
-        async def _publish_message() -> None:
-            await cls.publish_message(
+        async def _publish_message() -> str:
+            return await cls.publish_message(
                 topic_arn,
                 payload,
                 cast(Dict, message_attributes),
@@ -206,10 +249,9 @@ class AWSSNSSQSTransport(Invoker):
             )
 
         if wait:
-            await _publish_message()
+            return await _publish_message()
         else:
-            loop: Any = asyncio.get_event_loop()
-            loop.create_task(_publish_message())
+            return asyncio.create_task(_publish_message())
 
     @classmethod
     def get_topic_name(
@@ -1702,8 +1744,6 @@ class AWSSNSSQSTransport(Invoker):
                 task.cancel()
                 await task
 
-        loop: Any = asyncio.get_event_loop()
-
         stop_method = getattr(obj, "_stop_service", None)
 
         async def stop_service(*args: Any, **kwargs: Any) -> None:
@@ -1734,7 +1774,7 @@ class AWSSNSSQSTransport(Invoker):
 
         setattr(obj, "_started_service", started_service)
 
-        loop.create_task(receive_messages())
+        asyncio.create_task(receive_messages())
 
     @classmethod
     async def subscribe(cls, obj: Any, context: Dict) -> Optional[Callable]:


### PR DESCRIPTION
The SNS message identifier is returned from `tomodachi.aws_sns_sqs_publish` if it is called with `wait=True` (which is also the default if `wait` argument isn't supplied) or if `wait=False` instead an `asyncio.Task[str]` task is returned, which can be awaited to get the message identifier.

##### Using default value for `wait` (`wait=True`)

```python
sns_message_id: str = await aws_sns_sqs_publish(
    service,
    data,
    topic=topic,
)
```

##### Using explicit `wait=False`

```python
task: asyncio.Task[str] = await aws_sns_sqs_publish(
    service,
    data,
    topic=topic,
    wait=False,
)
sns_message_id = await task
```