### PR TITLE
Fixes function signature provided arguments for wrapped functions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,18 @@
 Changes
 =======
 
+0.25.1 (2023-08-xx)
+-------------------
+
+- Fix for an issue where a wrapped function is used as a handler function,
+  which would then cause the keyword argument provided transport values to
+  rely on the keyword arguments from the *wrapped function's* signature to be
+  used instead of the keyword arguments from the *wrapper function's* signature.
+
+  The bug was found to be present since the last release, which included major
+  refactoring of the *keyword argument provided transport values* functionality.
+
+
 0.25.0 (2023-06-24)
 -------------------
 

--- a/tests/services/wrapped_invoker_function_service.py
+++ b/tests/services/wrapped_invoker_function_service.py
@@ -83,12 +83,7 @@ class Service(tomodachi.Service):
 
     @sqs_wrapper("test-wrapped-invoker", queue_name="test-wrapped-invoker-{}".format(data_uuid))
     @sqs_wrapper("test-wrapped-invoker-2", queue_name="test-wrapped-invoker-2-{}".format(data_uuid))
-    async def sqs_handler(
-        self,
-        event: MessageEvent,
-        *args: Any,
-        **kwargs: Any,
-    ) -> None:
+    async def sqs_handler(self, event: MessageEvent, *args: Any, **kwargs: Any) -> None:
         if args or kwargs:
             raise Exception("function should be called without any additional arguments")
         if not event.sns_message_id or not event.topic:

--- a/tests/services/wrapped_invoker_function_service.py
+++ b/tests/services/wrapped_invoker_function_service.py
@@ -78,7 +78,6 @@ class Service(tomodachi.Service):
     async def multi_http_request_handler(
         self, request: web.Request, value1: str = "", value2: str = ""
     ) -> web.Response:
-        self.logger.info("log in handler", path=request.path, value1=value1, value2=value2)
         self.test_http_handler_called = True
         return web.Response(body=f"{request.path} {value1} {value2}")
 
@@ -96,7 +95,6 @@ class Service(tomodachi.Service):
             raise Exception("event should include sns_message_id and topic")
 
         if event.topic not in self.test_received_from_topics and event.data == self.data_uuid:
-            self.logger.info("log in handler", topic=event.topic, sns_message_id=event.sns_message_id)
             self.test_received_from_topics.add(event.topic)
             self.check_closer()
 

--- a/tests/services/wrapped_invoker_function_service.py
+++ b/tests/services/wrapped_invoker_function_service.py
@@ -1,0 +1,168 @@
+import asyncio
+import os
+import uuid
+from functools import wraps
+from typing import Any, Callable, Set
+
+import aiohttp
+from aiohttp import web
+
+import tomodachi
+
+data_uuid = str(uuid.uuid4())
+
+
+class MessageEvent:
+    def __init__(self, data: Any, topic: str, sns_message_id: str = "") -> None:
+        self.data = data
+        self.topic = topic
+        self.sns_message_id = sns_message_id
+
+
+def sqs_wrapper(*args: Any, **kwargs: Any) -> Any:
+    def _wrap(func: Callable) -> Any:
+        @tomodachi.aws_sns_sqs(*args, **kwargs)
+        @wraps(func, assigned=("__module__", "__doc__", "__name__", "__qualname__"))
+        async def _wrapper(self: Any, data: Any, topic: str, sns_message_id: str) -> None:
+            await func(self, event=MessageEvent(data, topic, sns_message_id))
+
+        return _wrapper
+
+    return _wrap
+
+
+class Service(tomodachi.Service):
+    name = "service"
+    options = tomodachi.Options(
+        http=tomodachi.Options.HTTP(port=0),
+        aws_sns_sqs=tomodachi.Options.AWSSNSSQS(
+            region_name=os.environ.get("TOMODACHI_TEST_AWS_REGION"),
+            aws_access_key_id=os.environ.get("TOMODACHI_TEST_AWS_ACCESS_KEY_ID"),
+            aws_secret_access_key=os.environ.get("TOMODACHI_TEST_AWS_ACCESS_SECRET"),
+            queue_name_prefix=os.environ.get("TOMODACHI_TEST_SQS_QUEUE_PREFIX") or "",
+            topic_prefix=os.environ.get("TOMODACHI_TEST_SNS_TOPIC_PREFIX") or "",
+        ),
+        aws_endpoint_urls=tomodachi.Options.AWSEndpointURLs(
+            sns=os.environ.get("TOMODACHI_TEST_AWS_SNS_ENDPOINT_URL") or None,
+            sqs=os.environ.get("TOMODACHI_TEST_AWS_SQS_ENDPOINT_URL") or None,
+        ),
+    )
+
+    closer: asyncio.Future
+    test_received_from_topics: Set[str]
+    test_topic_data_received: bool = False
+    test_http_handler_called: bool = False
+    test_http_endpoint_response: str = ""
+
+    data_uuid = data_uuid
+
+    def check_closer(self) -> None:
+        if all(
+            [
+                len(self.test_received_from_topics) == 2,
+                self.test_http_handler_called,
+                self.test_http_endpoint_response == "the-expected-response",
+            ]
+        ):
+            if not self.closer.done():
+                self.closer.set_result(None)
+
+    @tomodachi.http("GET", r"/")
+    async def basic_http_request_handler(self, request: web.Request) -> web.Response:
+        self.test_http_handler_called = True
+        return web.Response(body="the-expected-response")
+
+    @tomodachi.http("GET", r"/x/(?P<value1>[^/]+)/?")
+    @tomodachi.http("GET", r"/y(?P<value1>[^/]+)/(?P<value2>[^/]+)/?")
+    @tomodachi.http("GET", r"/z/?")
+    async def multi_http_request_handler(
+        self, request: web.Request, value1: str = "", value2: str = ""
+    ) -> web.Response:
+        self.logger.info("log in handler", path=request.path, value1=value1, value2=value2)
+        self.test_http_handler_called = True
+        return web.Response(body=f"{request.path} {value1} {value2}")
+
+    @sqs_wrapper("test-wrapped-invoker", queue_name="test-wrapped-invoker-{}".format(data_uuid))
+    @sqs_wrapper("test-wrapped-invoker-2", queue_name="test-wrapped-invoker-2-{}".format(data_uuid))
+    async def sqs_handler(
+        self,
+        event: MessageEvent,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        if args or kwargs:
+            raise Exception("function should be called without any additional arguments")
+        if not event.sns_message_id or not event.topic:
+            raise Exception("event should include sns_message_id and topic")
+
+        if event.topic not in self.test_received_from_topics and event.data == self.data_uuid:
+            self.logger.info("log in handler", topic=event.topic, sns_message_id=event.sns_message_id)
+            self.test_received_from_topics.add(event.topic)
+            self.check_closer()
+
+    async def _start_service(self) -> None:
+        self.closer = asyncio.Future()
+        self.test_received_from_topics = set()
+
+    async def _started_service(self) -> None:
+        async def publish(data: Any, topic: str, **kwargs: Any) -> None:
+            await tomodachi.aws_sns_sqs_publish(self, data, topic=topic, wait=False, **kwargs)
+
+        async def _async() -> None:
+            async def sleep_and_kill() -> None:
+                await asyncio.sleep(30.0)
+                if not self.closer.done():
+                    self.closer.set_result(None)
+
+            task = asyncio.ensure_future(sleep_and_kill())
+            await self.closer
+            if not task.done():
+                task.cancel()
+            tomodachi.exit()
+
+        asyncio.ensure_future(_async())
+
+        async def _async_publisher() -> None:
+            for _ in range(10):
+                if len(self.test_received_from_topics) == 2:
+                    break
+
+                if "test-wrapped-invoker" not in self.test_received_from_topics:
+                    await publish(self.data_uuid, "test-wrapped-invoker")
+
+                if "test-wrapped-invoker-2" not in self.test_received_from_topics:
+                    await publish(self.data_uuid, "test-wrapped-invoker-2")
+
+                await asyncio.sleep(0.5)
+
+        async def _http_requester() -> None:
+            port = getattr(self, "context", {}).get("_http_port")
+
+            async with aiohttp.ClientSession() as client:
+                response = await client.get("http://127.0.0.1:{}/x/4711".format(port))
+                if response.status != 200 or (await response.text()) != "/x/4711 4711 ":
+                    raise Exception("invalid response")
+
+            async with aiohttp.ClientSession() as client:
+                response = await client.get("http://127.0.0.1:{}/ytest/0".format(port))
+                if response.status != 200 or (await response.text()) != "/ytest/0 test 0":
+                    raise Exception("invalid response")
+
+            async with aiohttp.ClientSession() as client:
+                response = await client.get("http://127.0.0.1:{}/z".format(port))
+                if response.status != 200 or (await response.text()) != "/z  ":
+                    raise Exception("invalid response")
+
+            async with aiohttp.ClientSession() as client:
+                response = await client.get("http://127.0.0.1:{}/".format(port))
+                if response.status != 200:
+                    raise Exception("invalid response status code")
+                self.test_http_endpoint_response = await response.text()
+                self.check_closer()
+
+        asyncio.ensure_future(_async_publisher())
+        asyncio.ensure_future(_http_requester())
+
+    def stop_service(self) -> None:
+        if not self.closer.done():
+            self.closer.set_result(None)

--- a/tests/test_wrapped_invoker_function.py
+++ b/tests/test_wrapped_invoker_function.py
@@ -1,0 +1,34 @@
+import asyncio
+import time
+from typing import Any
+
+from run_test_service_helper import start_service
+
+
+def test_wrapped_invoker_functions(capsys: Any, loop: Any) -> None:
+    services, future = start_service("tests/services/wrapped_invoker_function_service.py", loop=loop)
+
+    assert services is not None
+    assert len(services) == 1
+    instance = services.get("service")
+    assert instance is not None
+
+    async def _async(loop: Any) -> None:
+        loop_until = time.time() + 10
+        while loop_until > time.time():
+            if all(
+                [
+                    len(instance.test_received_from_topics) == 2,
+                    instance.test_http_handler_called,
+                    instance.test_http_endpoint_response == "the-expected-response",
+                ]
+            ):
+                break
+            await asyncio.sleep(0.5)
+
+    loop.run_until_complete(_async(loop))
+
+    assert instance.test_received_from_topics == {"test-wrapped-invoker", "test-wrapped-invoker-2"}
+
+    instance.stop_service()
+    loop.run_until_complete(future)

--- a/tests/test_wrapped_invoker_function.py
+++ b/tests/test_wrapped_invoker_function.py
@@ -28,7 +28,7 @@ def test_wrapped_invoker_functions(capsys: Any, loop: Any) -> None:
 
     loop.run_until_complete(_async(loop))
 
-    assert instance.test_received_from_topics == {"test-wrapped-invoker", "test-wrapped-invoker-2"}
-
     instance.stop_service()
     loop.run_until_complete(future)
+
+    assert instance.test_received_from_topics == {"test-wrapped-invoker", "test-wrapped-invoker-2"}

--- a/tomodachi/invoker/base.py
+++ b/tomodachi/invoker/base.py
@@ -1,7 +1,6 @@
 import functools
-import inspect
 import types
-from typing import Any, Callable, Dict, Tuple, cast
+from typing import Any, Callable, Dict, Optional, Tuple, cast
 
 from tomodachi.options import Options
 
@@ -17,7 +16,12 @@ class Invoker(object):
     def decorator(cls, cls_func: Callable) -> Callable:
         def _wrapper(*args: Any, **kwargs: Any) -> Callable:
             def wrapper(func: Callable) -> Callable:
-                unwrapped_func = inspect.unwrap(func)
+                fn: Optional[Callable] = func
+                while fn:
+                    unwrapped_func = fn
+                    if getattr(fn, "__wrapped__", None) and not getattr(fn, FUNCTION_ATTRIBUTE, None):
+                        break
+                    fn = getattr(fn, "__wrapped__", None)
 
                 @functools.wraps(unwrapped_func)
                 async def _decorator(obj: Any, *a: Any, **kw: Any) -> Any:


### PR DESCRIPTION
Fix for an issue where a wrapped function is used as a handler function, which would then cause the keyword argument provided transport values to rely on the keyword arguments from the *wrapped function's* signature to be used instead of the keyword arguments from the *wrapper function's* signature.

The bug was found to be present since the last release, which included major refactoring of the *keyword argument provided transport values* functionality.

---

The error appeared when using a wrapper function such as this one, which expects values for `topic` and `sns_message_id`.

```python
def sqs_wrapper(*args: Any, **kwargs: Any) -> Any:
    def _wrap(func: Callable) -> Any:
        @tomodachi.aws_sns_sqs(*args, **kwargs)
        @wraps(func, assigned=("__module__", "__doc__", "__name__", "__qualname__"))
        async def _wrapper(self: Any, data: Any, topic: str, sns_message_id: str) -> None:
            await func(self, event=Event(data, topic, sns_message_id))

        return _wrapper

    return _wrap
```

The wrapped invoker is then used as the handler function's decorator replacing `@tomodachi.aws_sns_sqs`.

```python
class Service(tomodachi.Service):
    name = "service"

    @sqs_wrapper("test-topic", queue_name="test-queue")
    async def sqs_handler(self, event: MessageEvent) -> None:
         logging.info(f"topic: {event.topic}, sns_message_id: {event.sns_message_id}"
```

---

Test cases added including a (messy) test service which uses above mentioned invoker wrapper, as well as using some other wonky non-standard use-cases such as having multiple invoker decorators for the same handler, etc.