### PR TITLE
Updates interactions with the datetime library to avoid using deprecated functions datetime.utcnow() and datetime.utcfromtimestamp()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ _pypi_release: _check_release _check_build_time
 
 .PHONY: _set_build_time_value
 _set_build_time_value:
-	sed -i'' -e "s/^__build_time__ = \"[^\"]*\"/__build_time__ = \"`python -c "import datetime; print(datetime.datetime.utcnow().isoformat(timespec='microseconds') + 'Z')"`\"/" tomodachi/__version__.py
+	sed -i'' -e "s/^__build_time__ = \"[^\"]*\"/__build_time__ = \"`python -c "import datetime; print(datetime.datetime.now(datetime.timezone.utc).isoformat(timespec='microseconds').replace('+00:00', 'Z'))"`\"/" tomodachi/__version__.py
 	rm -f tomodachi/__version__.py-e
 
 .PHONY: _unset_build_time_value

--- a/tomodachi/helpers/build_time.py
+++ b/tomodachi/helpers/build_time.py
@@ -11,14 +11,18 @@ def get_time_since_build(timestamp: Optional[str] = None, build_time: Optional[s
         build_time = tomodachi_build_time
 
     if not timestamp:
-        timestamp = datetime.datetime.utcnow().isoformat(timespec="microseconds") + "Z"
+        timestamp = (
+            datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z")
+        )
 
     if build_time:
         try:
-            tomodachi_build_datetime = datetime.datetime.strptime(build_time, "%Y-%m-%dT%H:%M:%S.%f%z").replace(
-                tzinfo=None
+            tomodachi_build_datetime = datetime.datetime.strptime(build_time, "%Y-%m-%dT%H:%M:%S.%f%z").astimezone(
+                datetime.timezone.utc
             )
-            current_datetime = datetime.datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%S.%f%z").replace(tzinfo=None)
+            current_datetime = datetime.datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%S.%f%z").astimezone(
+                datetime.timezone.utc
+            )
             timedelta_since_tomodachi_build = current_datetime - tomodachi_build_datetime
             if timedelta_since_tomodachi_build.days == 0:
                 seconds = timedelta_since_tomodachi_build.seconds

--- a/tomodachi/launcher.py
+++ b/tomodachi/launcher.py
@@ -210,9 +210,8 @@ class ServiceLauncher(object):
                 tomodachi.logging.set_default_formatter()
                 tomodachi.logging.configure(log_level=log_level)
 
-            init_timestamp = time.time()
             init_timestamp_str = (
-                datetime.datetime.utcfromtimestamp(init_timestamp).isoformat(timespec="microseconds") + "Z"
+                datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z")
             )
 
             process_id = os.getpid()

--- a/tomodachi/launcher.py
+++ b/tomodachi/launcher.py
@@ -5,7 +5,6 @@ import os
 import platform
 import signal
 import sys
-import time
 import traceback
 from typing import Any, Callable, Dict, List, Optional, Set, Union, cast
 

--- a/tomodachi/logging.py
+++ b/tomodachi/logging.py
@@ -90,7 +90,9 @@ class LogProcessorTimestamp:
 
     def __call__(self, logger: WrappedLogger, method_name: str, event_dict: EventDict) -> EventDict:
         if self.key not in event_dict:
-            event_dict[self.key] = datetime.datetime.utcnow().isoformat(timespec="microseconds") + "Z"
+            event_dict[self.key] = (
+                datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z")
+            )
         return event_dict
 
 
@@ -348,7 +350,11 @@ class _PythonLoggingLoggerFormatter(logging.Formatter):
         self.style._fmt = fmt
 
     def formatTime(self, record: logging.LogRecord, datefmt: Optional[str] = None) -> str:
-        return datetime.datetime.utcfromtimestamp(record.created).isoformat(timespec="microseconds") + "Z"
+        return (
+            datetime.datetime.fromtimestamp(record.created, tz=datetime.timezone.utc)
+            .isoformat(timespec="microseconds")
+            .replace("+00:00", "Z")
+        )
 
     def __repr__(self) -> str:
         return "PythonLoggingFormatter"
@@ -420,7 +426,11 @@ class _StdLoggingFormatter(logging.Formatter):
             return ""
 
     def formatTime(self, record: logging.LogRecord, datefmt: Optional[str] = None) -> str:
-        return datetime.datetime.utcfromtimestamp(record.created).isoformat(timespec="microseconds") + "Z"
+        return (
+            datetime.datetime.fromtimestamp(record.created, tz=datetime.timezone.utc)
+            .isoformat(timespec="microseconds")
+            .replace("+00:00", "Z")
+        )
 
     def __repr__(self) -> str:
         name = self._name or self.__class__.__name__

--- a/tomodachi/transport/schedule.py
+++ b/tomodachi/transport/schedule.py
@@ -527,7 +527,9 @@ class Scheduler(Invoker):
 
                     current_time = time.time()
                     invocation_time = (
-                        datetime.datetime.utcfromtimestamp(int(prev_call_at or current_time)).isoformat() + "Z"
+                        datetime.datetime.fromtimestamp(int(prev_call_at or current_time), tz=datetime.timezone.utc)
+                        .isoformat()
+                        .replace("+00:00", "Z")
                     )
 
                     task = asyncio.ensure_future(handler(invocation_time=invocation_time))
@@ -535,8 +537,9 @@ class Scheduler(Invoker):
                         getattr(task, "set_name")(
                             "{}/{}".format(
                                 func.__qualname__,
-                                datetime.datetime.utcfromtimestamp(current_time).isoformat(timespec="microseconds")
-                                + "Z",
+                                datetime.datetime.fromtimestamp(current_time, tz=datetime.timezone.utc)
+                                .isoformat(timespec="microseconds")
+                                .replace("+00:00", "Z"),
                             )
                         )
                     tasks.append(task)


### PR DESCRIPTION
* [GitHub — python/cpython [issue #103857]](https://github.com/python/cpython/issues/103857)
* [GitHub — python/cpython [pull request #103858]](https://github.com/python/cpython/pull/103858/files#diff-2a8962dcecb109859cedd81ddc5729bea57d156e0947cb8413f99781a0860fd1R1802)

Fixes for the following deprecation warnings since Python 3.12:

* DeprecationWarning: `datetime.utcnow()` is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: `datetime.now(datetime.UTC)`
* DeprecationWarning: `datetime.utcfromtimestamp()` is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: `datetime.fromtimestamp(timestamp, datetime.UTC)`.