### PR TITLE
AWS SNS SQS: pass FIFO message attributes to tomodachi handler function

### DIFF
--- a/tests/services/aws_sns_sqs_service_with_middleware.py
+++ b/tests/services/aws_sns_sqs_service_with_middleware.py
@@ -166,6 +166,8 @@ class AWSSNSSQSService(tomodachi.Service):
     test_receipt_handle: str = ""
     test_message_attributes: Optional[Dict] = None
     test_approximate_receive_count: int = 0
+    test_message_deduplication_id: Optional[None] = None
+    test_message_group_id: Optional[None] = None
     test_middleware_values: Optional[Dict] = None
 
     data_uuid = data_uuid
@@ -184,6 +186,8 @@ class AWSSNSSQSService(tomodachi.Service):
         message_attributes: Dict,
         initial_a_value: int,
         topic: str,
+        message_deduplication_id: Optional[None],
+        message_group_id: Optional[None],
         a_value: int = 0,
         another_value: int = 42,
         queue_url: str = "",
@@ -199,6 +203,8 @@ class AWSSNSSQSService(tomodachi.Service):
             self.test_receipt_handle = receipt_handle
             self.test_message_attributes = message_attributes
             self.test_approximate_receive_count = approximate_receive_count
+            self.test_message_deduplication_id = message_deduplication_id
+            self.test_message_group_id = message_group_id
             self.test_middleware_values = {
                 "kwarg_abc": kwarg_abc,
                 "kwarg_xyz": kwarg_xyz,

--- a/tests/test_aws_sns_sqs_service_with_middleware.py
+++ b/tests/test_aws_sns_sqs_service_with_middleware.py
@@ -34,6 +34,8 @@ def test_start_aws_sns_sqs_service_with_middleware(capsys: Any, loop: Any) -> No
         assert len(instance.test_queue_url) > 1
         assert len(instance.test_receipt_handle) > 1
         assert instance.test_approximate_receive_count >= 1
+        assert instance.test_message_deduplication_id is None
+        assert instance.test_message_group_id is None
         assert {k: v for k, v in instance.test_message_attributes.items() if k not in ("traceparent",)} == {
             "attr_1": "value_1",
             "attr_2": "value_2",


### PR DESCRIPTION
When working with FIFO queues and custom tomodachi middlewares, we need access to `message_deduplication_id` and `message_group_id`.

Change summary:
- Passing `message_deduplication_id` and `message_group_id` to handler function
- If a handler is not `fifo`, both attributes will be set to None

It's useful in custom SQS middlewares that, for example, move messages to dead-letter-queues and must preserve `MessageDeduplicationId` and `MessageGroupId`.