### PR TITLE
Typing fix for getting uvloop.__version__ value

### DIFF
--- a/tomodachi/cli/__init__.py
+++ b/tomodachi/cli/__init__.py
@@ -171,7 +171,7 @@ class CLI:
             # Optional
             import uvloop  # noqa  # isort:skip
 
-            uvloop_version = uvloop.__version__  # type: ignore
+            uvloop_version = str(getattr(uvloop, "__version__", ""))
             if output_versions:
                 print("uvloop/{}".format(uvloop_version))
         except ModuleNotFoundError:  # pragma: no cover

--- a/tomodachi/helpers/banner.py
+++ b/tomodachi/helpers/banner.py
@@ -72,7 +72,7 @@ def render_banner(
                 import uvloop  # noqa  # isort:skip
 
                 if event_loop_version is None:
-                    event_loop_version = str(uvloop.__version__)  # type: ignore
+                    event_loop_version = str(getattr(uvloop, "__version__", ""))
             elif "asyncio." in str(loop.__class__):
                 event_loop_alias = "asyncio"
             else:

--- a/tomodachi/launcher.py
+++ b/tomodachi/launcher.py
@@ -222,7 +222,7 @@ class ServiceLauncher(object):
                     event_loop_alias = "uvloop"
                     import uvloop  # noqa  # isort:skip
 
-                    event_loop_version = str(uvloop.__version__)  # type: ignore
+                    event_loop_version = str(getattr(uvloop, "__version__", ""))
                 elif "asyncio." in str(loop.__class__):
                     event_loop_alias = "asyncio"
                 else:


### PR DESCRIPTION
Gets `uvloop` version with `getattr` instead of referencing ModuleType attribute directly, in order to not have to include ignore type comment.