### PR TITLE
Correction of message attributes type definition for AWS SNS+SQS

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -329,13 +329,13 @@ crt = ["awscrt (==0.20.11)"]
 
 [[package]]
 name = "botocore-stubs"
-version = "1.34.136"
+version = "1.34.139"
 description = "Type annotations and code completion for botocore"
 optional = false
 python-versions = "<4.0,>=3.8"
 files = [
-    {file = "botocore_stubs-1.34.136-py3-none-any.whl", hash = "sha256:f8a8716d9f1b8387acce6ef35d9428ed4ef1584dbeb6cce3f2f95ba6ff8120f7"},
-    {file = "botocore_stubs-1.34.136.tar.gz", hash = "sha256:b97bece44abc9f16c1fcb022d3f03c22d411ea3dcb4730207a318eb8e6ef63e7"},
+    {file = "botocore_stubs-1.34.139-py3-none-any.whl", hash = "sha256:fa91cfa4c4ffa150af5a7b264ae7486a109ca342038404d1b4c8b2a17bda6724"},
+    {file = "botocore_stubs-1.34.139.tar.gz", hash = "sha256:ee55b126f1ed3a4474f58060e03b6514c0c3b3ecce8a48b4171119e7657a142d"},
 ]
 
 [package.dependencies]
@@ -477,13 +477,13 @@ files = [
 
 [[package]]
 name = "certifi"
-version = "2024.6.2"
+version = "2024.7.4"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "certifi-2024.6.2-py3-none-any.whl", hash = "sha256:ddc6c8ce995e6987e7faf5e3f1b02b302836a0e5d98ece18392cb1a36c72ad56"},
-    {file = "certifi-2024.6.2.tar.gz", hash = "sha256:3cd43f1c6fa7dedc5899d69d3ad0398fd018ad1a17fba83ddaf78aa46c747516"},
+    {file = "certifi-2024.7.4-py3-none-any.whl", hash = "sha256:c198e21b1289c2ab85ee4e67bb4b4ef3ead0892059901a8d5b622f24a1101e90"},
+    {file = "certifi-2024.7.4.tar.gz", hash = "sha256:5a1e7645bc0ec61a09e26c36f6106dd4cf40c6db3a1fb6352b0244e7fb057c7b"},
 ]
 
 [[package]]
@@ -1760,18 +1760,18 @@ use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "setuptools"
-version = "70.1.1"
+version = "70.2.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = true
 python-versions = ">=3.8"
 files = [
-    {file = "setuptools-70.1.1-py3-none-any.whl", hash = "sha256:a58a8fde0541dab0419750bcc521fbdf8585f6e5cb41909df3a472ef7b81ca95"},
-    {file = "setuptools-70.1.1.tar.gz", hash = "sha256:937a48c7cdb7a21eb53cd7f9b59e525503aa8abaf3584c730dc5f7a5bec3a650"},
+    {file = "setuptools-70.2.0-py3-none-any.whl", hash = "sha256:b8b8060bb426838fbe942479c90296ce976249451118ef566a5a0b7d8b78fb05"},
+    {file = "setuptools-70.2.0.tar.gz", hash = "sha256:bd63e505105011b25c3c11f753f7e3b8465ea739efddaccef8f0efac2137bac1"},
 ]
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "importlib-metadata", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "jaraco.test", "mypy (==1.10.0)", "packaging (>=23.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.1)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy", "pytest-perf", "pytest-ruff (>=0.3.2)", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "importlib-metadata", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "jaraco.test", "mypy (==1.10.0)", "packaging (>=23.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy", "pytest-perf", "pytest-ruff (>=0.3.2)", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
 name = "six"
@@ -2249,13 +2249,13 @@ typing-extensions = {version = ">=4.1.0", markers = "python_version < \"3.12\""}
 
 [[package]]
 name = "types-awscrt"
-version = "0.20.12"
+version = "0.21.0"
 description = "Type annotations and code completion for awscrt"
 optional = false
 python-versions = "<4.0,>=3.7"
 files = [
-    {file = "types_awscrt-0.20.12-py3-none-any.whl", hash = "sha256:521ce54cc4dad9fe6480556bb0f8315a508106938ba1f2a0baccfcea7d4a4dee"},
-    {file = "types_awscrt-0.20.12.tar.gz", hash = "sha256:0beabdde0205dc1da679ea464fd3f98b570ef4f0fc825b155a974fb51b21e8d9"},
+    {file = "types_awscrt-0.21.0-py3-none-any.whl", hash = "sha256:026f882d4d23f04c5b2ab08d6fefd627842537009cd00e9f78dd4960314d51aa"},
+    {file = "types_awscrt-0.21.0.tar.gz", hash = "sha256:06aa247fe5ccf0b86428e5289aeabf67f967e10861f211c16c19e7d2542a70a9"},
 ]
 
 [[package]]
@@ -2636,4 +2636,4 @@ uvloop = ["uvloop"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "501d47606809dfcc3071f34f9233375f9ab7510167616c706f736a70b886e0d2"
+content-hash = "dfa81bb0395fc43202a5a581878dae4ade1cb032e550765b9f6d099a68a5788a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ Changelog = "https://github.com/kalaspuff/tomodachi/blob/master/CHANGELOG.md"
 python = "^3.8"
 
 aioamqp = ">=0.13.0,<0.16.0"
-aiobotocore = ">=1.3.0,<2.14.0"
+aiobotocore = "^2.0.0"
 tzlocal = ">=1.4,<6.0"
 pytz = "*"
 cchardet = { version = ">=2.1.7", python = "<3.10" }
@@ -56,7 +56,7 @@ asahi = ">=0.1,<0.3"
 structlog = ">=21.5.0,<25.0.0"
 
 # derived from aiobotocore for dependency resolution speed in same cases.
-botocore = ">=1.20.106"
+botocore = ">=1.22.8"
 
 # extras
 protobuf = { version = ">=3.20.0", optional = true }
@@ -110,7 +110,7 @@ types-protobuf = { version = ">=0.1.13", markers = "sys_platform != \"win32\"" }
 types-pytz = { version = ">=2021.1.0", markers = "sys_platform != \"win32\"" }
 types-tzlocal = { version = ">=0.1.1", markers = "sys_platform != \"win32\"" }
 types-setuptools = { version = ">=16.0", markers = "sys_platform != \"win32\"" }
-types-aiobotocore = { version = ">=1.3.0", markers = "sys_platform != \"win32\"", extras = ["sns", "sqs"] }
+types-aiobotocore = { version = ">=2.0.0,<3.0.0", markers = "sys_platform != \"win32\"", extras = ["sns", "sqs"] }
 
 [tool.poetry.scripts]
 tomodachi = "tomodachi.cli:cli_entrypoint"

--- a/tomodachi/transport/aws_sns_sqs.py
+++ b/tomodachi/transport/aws_sns_sqs.py
@@ -17,6 +17,7 @@ import time
 import uuid
 import warnings
 from typing import (
+    IO,
     TYPE_CHECKING,
     Any,
     Callable,
@@ -44,6 +45,7 @@ import aiohttp
 import aiohttp.client_exceptions
 import botocore
 import botocore.exceptions
+from aiobotocore.response import StreamingBody
 from botocore.parsers import ResponseParserError
 
 from tomodachi import get_contextvar, logging
@@ -201,9 +203,11 @@ class _MessageAttributeValueBaseTypeDef(TypedDict):
 
 class _MessageAttributeValueTypeDef(_MessageAttributeValueBaseTypeDef, total=False):
     StringValue: str
-    BinaryValue: Any  # SNS wants "Union[str, bytes, IO[Any], aiobotocore.response.StreamingBody]". SQS wants "bytes".
-    StringListValues: List[str]
-    BinaryListValues: List[bytes]
+    BinaryValue: Union[
+        str, bytes, IO[Any], StreamingBody, Any
+    ]  # SNS wants "Union[str, bytes, IO[Any], aiobotocore.response.StreamingBody]". SQS wants "bytes".
+    StringListValues: Sequence[str]
+    BinaryListValues: Sequence[Union[str, bytes, IO[Any], StreamingBody, Any]]
 
 
 MessageAttributesTypeDef = Dict[str, _MessageAttributeValueTypeDef]

--- a/tomodachi/transport/aws_sns_sqs.py
+++ b/tomodachi/transport/aws_sns_sqs.py
@@ -201,6 +201,7 @@ class _MessageAttributeValueBaseTypeDef(TypedDict):
     DataType: str
 
 
+# Any value of binary Union kept for compatibility with older Python versions in combination with older aiobotocore setups.
 class _MessageAttributeValueTypeDef(_MessageAttributeValueBaseTypeDef, total=False):
     StringValue: str
     BinaryValue: Union[


### PR DESCRIPTION
* Correction of message attributes type definition. Now also aligns better with updated types-aiobotocore libraries.
* Updated version restriction of `aiobotocore` as 1.x actually isn't supported any longer.