### PR TITLE
fix: fixes issue when reading multipart requests (or in same cases the post body) within service http handler, because it was previously already read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.28.1 (2024-xx-xx)
 
-- ...
+- Fixes an issue when attempting to call reading functions on a multipart web request in a handler would previously result in an "Could not find starting boundary in ..." error. This fix will now again make it possible to upload files as multipart web requests, and read those files from await request.post() in service http handlers.
 
 ## 0.28.0 (2024-10-25)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -256,6 +256,7 @@ filterwarnings = [
     "ignore:Type google._upb._message.MessageMapContainer uses PyType_Spec with a metaclass that has custom tp_new..*:DeprecationWarning:importlib._bootstrap",
     "ignore:Type google._upb._message.ScalarMapContainer uses PyType_Spec with a metaclass that has custom tp_new..*:DeprecationWarning:importlib._bootstrap",
     "ignore:datetime.datetime.utcnow\\(\\) is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC:DeprecationWarning:botocore.auth",
+    "ignore:unread_data\\(\\) is deprecated and will be removed in future releases \\(#3260\\):DeprecationWarning:tomodachi.transport.http",
 ]
 
 [tool.coverage.run]

--- a/tests/services/http_service.py
+++ b/tests/services/http_service.py
@@ -1,7 +1,8 @@
 import asyncio
-from typing import Any, Callable, Dict, Tuple, Union
+from typing import Any, Callable, Dict, Tuple, Union, cast
 
 from aiohttp import web
+from aiohttp.web_request import FileField
 from opentelemetry.sdk.trace import TracerProvider
 
 import tomodachi
@@ -158,6 +159,16 @@ class HttpService(tomodachi.Service):
             self.websocket_received_data = data
 
         return _receive
+
+    @tomodachi.http("POST", r"/file-upload")
+    async def file_upload(self, request: web.Request) -> bytes:
+        data = await request.post()
+        file_from_request = cast(FileField, data.get("file"))
+        filename = file_from_request.filename
+        content = file_from_request.file.read()
+        file_from_request.file.close()
+
+        return filename.encode("utf-8") + b": " + content
 
     async def _start_service(self) -> None:
         self.closer = asyncio.Future()

--- a/tests/test_http_service.py
+++ b/tests/test_http_service.py
@@ -326,6 +326,18 @@ def test_request_http_service(capsys: Any, loop: Any) -> None:
                 await ws.close()
                 assert instance.websocket_received_data == data
 
+        async with aiohttp.ClientSession(loop=loop) as client:
+            with open(pathlib.Path("{}/tests/static_files/image.png".format(os.path.realpath(os.getcwd()))), "rb") as f:
+                content = f.read()
+                f.seek(0)
+                response = await client.post(
+                    "http://127.0.0.1:{}/file-upload".format(port),
+                    data={"file": f},
+                )
+                assert response is not None
+                assert response.status == 200
+                assert await response.read() == b"image.png: " + content
+
     loop.run_until_complete(_async(loop))
     instance.stop_service()
     loop.run_until_complete(future)

--- a/tomodachi/transport/http.py
+++ b/tomodachi/transport/http.py
@@ -876,7 +876,11 @@ class HttpTransport(Invoker):
                         ):
                             request._read_bytes = request.content._read_nowait(-1)
                         else:
-                            await request.read()
+                            request_body = await request.read()
+                            # reads data into _post cache, however deprecated use, might be removed in aiohttp 4
+                            # https://github.com/aio-libs/aiohttp/issues/3260
+                            request.content.unread_data(request_body)
+                            await request.post()
                     except web.HTTPException as exc:
                         # internal aiohttp exception raised (for example if entity too large)
                         response = exc


### PR DESCRIPTION
Previously attempting to call reading functions on a multipart web request in a handler would result in an error, such as "Could not find starting boundary in ...". The bug was first introduced in tomodachi 0.26.0, where reading of http requests was restructured.

This fix will now again make it possible to upload files as multipart web requests, and read those files from `await request.post()` in service http handlers.

### Issue

* https://github.com/kalaspuff/tomodachi/issues/1814