### PR TITLE
fix: allow message processing of duplicate message after 60 seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changes
 
-## 0.28.2 (2024-xx-xx)
+## 0.28.2 (2025-02-14)
 
-- ...
+- Fixes a bug for AWS SQS queues with dead-letter queue configured which would trigger if SQS.DeleteMessage calls would unexpectedly fail or fail all retries for a message and the same message would be received again to the same consumer over and over again, where it would be ignored as a duplicated SQS message, until it would be sent to the DLQ. Even if the message was redrived to the queue and the same consumer would keep receiving it, it would still ignore the message as a duplicate. This would cause the message to be stuck in a loop.
+
+  Note that this change will run the handler function of the consumer after 60 seconds has passed and it receives the message again, which in a setup where a service has a single receiving consumer leaves responsibility of the handler to handle idempotency more strictly, in the same way as in setups with multiple consumers.
 
 ## 0.28.1 (2024-10-29)
 

--- a/tomodachi/__version__.py
+++ b/tomodachi/__version__.py
@@ -1,6 +1,6 @@
 from typing import Tuple, Union
 
-__version_info__: Tuple[Union[int, str], ...] = (0, 28, 2, "dev0")
+__version_info__: Tuple[Union[int, str], ...] = (0, 28, 2)
 __version__: str = "".join([".{}".format(str(n)) if type(n) is int else str(n) for n in __version_info__]).replace(
     ".", "", 1 if type(__version_info__[0]) is int else 0
 )

--- a/tomodachi/transport/aws_sns_sqs.py
+++ b/tomodachi/transport/aws_sns_sqs.py
@@ -960,7 +960,7 @@ class AWSSNSSQSTransport(Invoker):
                             context["_aws_sns_sqs_received_messages"] = {
                                 k: v
                                 for k, v in context["_aws_sns_sqs_received_messages"].items()
-                                if time.time() - v > 60
+                                if time.time() - v < 60
                             }
 
                     if args_set:


### PR DESCRIPTION
Fixes a bug for AWS SQS queues with dead-letter queue configured which would trigger if SQS.DeleteMessage calls would unexpectedly fail or fail all retries for a message and the same message would be received again to the same consumer over and over again, where it would be ignored as a duplicated SQS message, until it would be sent to the DLQ. Even if the message was redrived to the queue and the same consumer would keep receiving it, it would still ignore the message as a duplicate. This would cause the message to be stuck in a loop.

  Note that this change will run the handler function of the consumer after 60 seconds has passed and it receives the message again, which in a setup where a service has a single receiving consumer leaves responsibility of the handler to handle idempotency more strictly, in the same way as in setups with multiple consumers.